### PR TITLE
Add order_number field to CollectionResponse

### DIFF
--- a/src/DTO/Response/CollectionResponse.php
+++ b/src/DTO/Response/CollectionResponse.php
@@ -13,5 +13,7 @@ final class CollectionResponse
         public readonly string $name,
         #[SerializedName('french_name')]
         public readonly string $frenchName,
+        #[SerializedName('order_number')]
+        public readonly int $orderNumber,
     ) {}
 }

--- a/src/Factory/CollectionResponseFactory.php
+++ b/src/Factory/CollectionResponseFactory.php
@@ -24,10 +24,14 @@ final class CollectionResponseFactory
         /** @var scalar $frenchName */
         $frenchName = $row['french_name'];
 
+        /** @var scalar $orderNumber */
+        $orderNumber = $row['order_number'];
+
         return new CollectionResponse(
             slug: (string) $slug,
             name: (string) $name,
             frenchName: (string) $frenchName,
+            orderNumber: (int) $orderNumber,
         );
     }
 

--- a/src/Repository/CollectionsRepository.php
+++ b/src/Repository/CollectionsRepository.php
@@ -40,7 +40,8 @@ class CollectionsRepository extends ServiceEntityRepository
         $sql = <<<'SQL'
             SELECT      name,
                         french_name as "french_name",
-                        slug
+                        slug,
+                        order_number
             FROM        collection
             WHERE       deleted_at IS NULL
             ORDER BY    order_number

--- a/tests/resources/fixtures/collections_response.json
+++ b/tests/resources/fixtures/collections_response.json
@@ -2,41 +2,49 @@
   {
     "slug": "swshdynamaxadventuresbosses",
     "name": "Sword, Shield - Dynamax Adventures bosses",
-    "french_name": "Sword, Shield - Boss des expéditions Dynamax"
+    "french_name": "Sword, Shield - Boss des expéditions Dynamax",
+    "order_number": 11
   },
   {
     "slug": "svmassoutbreakspaldea",
     "name": "Scarlet, Violet - Paldea's outbreaks",
-    "french_name": "Scarlet, Violet - Apparitions massives de Paldea"
+    "french_name": "Scarlet, Violet - Apparitions massives de Paldea",
+    "order_number": 20
   },
   {
     "slug": "svmassoutbreakskitakami",
     "name": "Scarlet, Violet - Kitakami's outbreaks",
-    "french_name": "Scarlet, Violet - Apparitions massives de Kitakami"
+    "french_name": "Scarlet, Violet - Apparitions massives de Kitakami",
+    "order_number": 21
   },
   {
     "slug": "svmassoutbreaksterrarium",
     "name": "Scarlet, Violet - Terrarium's outbreaks",
-    "french_name": "Scarlet, Violet - Apparitions massives du Terrarium"
+    "french_name": "Scarlet, Violet - Apparitions massives du Terrarium",
+    "order_number": 22
   },
   {
     "slug": "svtransferable",
     "name": "Scarlet, Violet - Transferable",
-    "french_name": "Scarlet, Violet - Transférable"
+    "french_name": "Scarlet, Violet - Transférable",
+    "order_number": 23
   },
   {
     "slug": "pogoshadow",
     "name": "Pokemon Go - Shadow",
-    "french_name": "Pokemon Go - Obscurs"
+    "french_name": "Pokemon Go - Obscurs",
+    "order_number": 50
   },
   {
     "slug": "pogoshadowshiny",
     "name": "Pokemon Go - Shiny Shadow",
-    "french_name": "Pokemon Go - Obscurs Chromatique"
+    "french_name": "Pokemon Go - Obscurs Chromatique",
+    "order_number": 51
   },
   {
     "slug": "pogodynamax",
     "name": "Pokemon Go - Dynamax",
-    "french_name": "Pokemon Go - Dynamax"
+    "french_name": "Pokemon Go - Dynamax",
+    "order_number": 52
   }
 ]

--- a/tests/src/Integration/Controller/CollectionsControllerTest.php
+++ b/tests/src/Integration/Controller/CollectionsControllerTest.php
@@ -34,18 +34,21 @@ final class CollectionsControllerTest extends AbstractTestControllerApi
             'slug' => 'swshdynamaxadventuresbosses',
             'name' => 'Sword, Shield - Dynamax Adventures bosses',
             'french_name' => 'Sword, Shield - Boss des expéditions Dynamax',
+            'order_number' => 11,
         ], $content[0]);
 
         $this->assertEquals([
             'slug' => 'svmassoutbreaksterrarium',
             'name' => "Scarlet, Violet - Terrarium's outbreaks",
             'french_name' => 'Scarlet, Violet - Apparitions massives du Terrarium',
+            'order_number' => 22,
         ], $content[3]);
 
         $this->assertEquals([
             'slug' => 'pogodynamax',
             'name' => 'Pokemon Go - Dynamax',
             'french_name' => 'Pokemon Go - Dynamax',
+            'order_number' => 52,
         ], $content[7]);
     }
 

--- a/tests/src/Unit/DTO/Response/CollectionResponseTest.php
+++ b/tests/src/Unit/DTO/Response/CollectionResponseTest.php
@@ -22,11 +22,13 @@ final class CollectionResponseTest extends TestCase
             slug: 'pogodynamax',
             name: 'Pokemon Go - Dynamax',
             frenchName: 'Pokemon Go - Dynamax',
+            orderNumber: 52,
         );
 
         self::assertSame('pogodynamax', $response->slug);
         self::assertSame('Pokemon Go - Dynamax', $response->name);
         self::assertSame('Pokemon Go - Dynamax', $response->frenchName);
+        self::assertSame(52, $response->orderNumber);
     }
 
     #[Test]
@@ -36,10 +38,12 @@ final class CollectionResponseTest extends TestCase
             slug: 'scarletviolet',
             name: 'Scarlet & Violet',
             frenchName: 'Écarlate & Violet',
+            orderNumber: 1,
         );
 
         self::assertSame('scarletviolet', $response->slug);
         self::assertSame('Scarlet & Violet', $response->name);
         self::assertSame('Écarlate & Violet', $response->frenchName);
+        self::assertSame(1, $response->orderNumber);
     }
 }

--- a/tests/src/Unit/Factory/CollectionResponseFactoryTest.php
+++ b/tests/src/Unit/Factory/CollectionResponseFactoryTest.php
@@ -23,6 +23,7 @@ final class CollectionResponseFactoryTest extends TestCase
             'slug' => 'swshdynamaxadventuresbosses',
             'name' => 'Sword, Shield - Dynamax Adventures bosses',
             'french_name' => 'Sword, Shield - Boss des expéditions Dynamax',
+            'order_number' => 11,
         ];
 
         $response = CollectionResponseFactory::fromSqlRow($row);
@@ -30,6 +31,7 @@ final class CollectionResponseFactoryTest extends TestCase
         self::assertSame('swshdynamaxadventuresbosses', $response->slug);
         self::assertSame('Sword, Shield - Dynamax Adventures bosses', $response->name);
         self::assertSame('Sword, Shield - Boss des expéditions Dynamax', $response->frenchName);
+        self::assertSame(11, $response->orderNumber);
     }
 
     #[Test]
@@ -39,6 +41,7 @@ final class CollectionResponseFactoryTest extends TestCase
             'slug' => 123,
             'name' => 456,
             'french_name' => 789,
+            'order_number' => '42',
         ];
 
         $response = CollectionResponseFactory::fromSqlRow($row);
@@ -46,6 +49,7 @@ final class CollectionResponseFactoryTest extends TestCase
         self::assertSame('123', $response->slug);
         self::assertSame('456', $response->name);
         self::assertSame('789', $response->frenchName);
+        self::assertSame(42, $response->orderNumber);
     }
 
     #[Test]
@@ -56,11 +60,13 @@ final class CollectionResponseFactoryTest extends TestCase
                 'slug' => 'swshdynamaxadventuresbosses',
                 'name' => 'Sword, Shield - Dynamax Adventures bosses',
                 'french_name' => 'Sword, Shield - Boss des expéditions Dynamax',
+                'order_number' => 11,
             ],
             [
                 'slug' => 'pogodynamax',
                 'name' => 'Pokemon Go - Dynamax',
                 'french_name' => 'Pokemon Go - Dynamax',
+                'order_number' => 52,
             ],
         ];
 


### PR DESCRIPTION
Expose the collection's order_number from the DB query through the DTO, factory and serialized API response so clients can sort collections correctly.