### PR TITLE
Resync /app/public into the shared volume on every prod container start

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -109,3 +109,18 @@ RUN rm .env \
 ## > Cleanup
 
 RUN chown -R www-data:www-data var/
+
+## < Sync /app/public into the volume shared with nginx on every start
+## (see docker-entrypoint-prod.sh for why this can't just rely on the
+## COPY above: /app/public is overlaid by a named Docker volume at runtime).
+# hadolint ignore=DL3018
+RUN apk add --no-cache rsync \
+	&& mv public public-src
+COPY --link .docker/php/docker-entrypoint-prod.sh /usr/local/bin/docker-entrypoint-prod.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-prod.sh
+
+ENTRYPOINT ["docker-entrypoint-prod.sh"]
+## Note: setting ENTRYPOINT resets any CMD inherited from the base image, so
+## it must be redeclared explicitly to keep starting php-fpm by default.
+CMD ["php-fpm"]
+## > Sync /app/public into the volume shared with nginx on every start

--- a/.docker/php/docker-entrypoint-prod.sh
+++ b/.docker/php/docker-entrypoint-prod.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# /app/public is a named Docker volume shared read-only with the nginx
+# container. Docker only auto-populates a named volume from the image the
+# first time it's created (when empty); on every later deploy the volume
+# keeps stale content and new/changed files under public/ never reach it.
+# Resync explicitly from the golden copy baked into the image on every start.
+rsync -a --delete /app/public-src/ /app/public/
+
+exec docker-php-entrypoint "$@"


### PR DESCRIPTION
project_public is a named Docker volume shared between php and nginx in prod/staging. Docker only auto-populates a named volume from the image the first time it's created; later deploys never sync new or changed files under public/ into it, so nginx keeps serving stale/missing assets.

Bake public/ as public-src/ in the image and rsync it into /app/public via a new entrypoint on every container start, so every deploy actually reaches the shared volume. Same fix applied to pokenini-web and pokenini-back, which share this deployment pattern.