### PR TITLE
Add automated Composer updates workflow (personal Dependabot)

### DIFF
--- a/.github/workflows/composer_updates.yml
+++ b/.github/workflows/composer_updates.yml
@@ -1,0 +1,58 @@
+name: Composer Updates
+
+on:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch: ~
+
+permissions:
+  contents: read
+
+concurrency:
+  group: composer-updates
+  cancel-in-progress: true
+
+jobs:
+  composer-updates:
+    name: Update Composer dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare PHP
+        uses: ./.github/actions/local-php
+
+      - name: Update main app dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=./
+
+      - name: Update deptrac dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/deptrac
+
+      - name: Update infection dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/infection
+
+      - name: Update jsonlint dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/jsonlint
+
+      - name: Update php-cs-fixer dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/php-cs-fixer
+
+      - name: Update phpmd dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/phpmd
+
+      - name: Update phpstan dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/phpstan
+
+      - name: Update psalm dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/psalm
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          branch: chore/composer-updates
+          delete-branch: true
+          commit-message: "Composers updates"
+          title: "Composers updates"
+          labels: dependencies

--- a/docs/superpowers/plans/2026-07-12-composer-updates-automation.md
+++ b/docs/superpowers/plans/2026-07-12-composer-updates-automation.md
@@ -1,0 +1,123 @@
+# Composer Updates Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a GitHub Actions workflow that runs `composer update --bump-after-update` across the main app and its 6 tool sub-projects daily, then opens/updates a single pull request with the result — a personal Dependabot equivalent.
+
+**Architecture:** One new workflow file, `.github/workflows/composer_updates.yml`, triggered by `schedule` + `workflow_dispatch`. It reuses the existing `./.github/actions/local-php` composite action for PHP setup (no Docker needed), runs 8 sequential `composer update` steps mirroring the `updates` Makefile target, then uses `peter-evans/create-pull-request@v7` with a fixed branch name to open or refresh one PR.
+
+**Tech Stack:** GitHub Actions, Composer, `peter-evans/create-pull-request@v7`, `actions/checkout@v6`.
+
+## Global Constraints
+
+- Bundle all 8 `composer update` calls (main app + `deptrac`, `infection`, `jsonlint`, `php-cs-fixer`, `phpmd`, `phpstan`, `psalm`) into one PR — no per-tool PR splitting.
+- Reuse the existing `./.github/actions/local-php` composite action for PHP setup — do not start the Docker compose stack.
+- Use `secrets.PAT_TOKEN` (already agreed as the secret name) for both checkout and PR creation, so the resulting PR is not authored by the default `GITHUB_TOKEN` and therefore actually triggers `ci_codequality.yml`, `ci_tests.yml`, and `security.yml` (which listen on `pull_request: ~`).
+- Fixed PR branch name `chore/composer-updates` with `delete-branch: true`, so daily runs update the same PR instead of creating new ones.
+- Commit/PR title: `Composers updates` (matches historical manual commits, e.g. `7616b28`).
+- Apply the existing `dependencies` repo label to the PR.
+- Cron: `17 4 * * *` (04:17 UTC daily).
+- Per user's standing instruction: do **not** commit any changes automatically. Leave changes staged/unstaged; only commit if the user explicitly asks.
+
+---
+
+### Task 1: Add the `composer_updates.yml` workflow
+
+**Files:**
+- Create: `.github/workflows/composer_updates.yml`
+
+**Interfaces:**
+- Consumes: `./.github/actions/local-php` (composite action, no inputs, sets up PHP 8.5 with the extensions the repo's composer projects need — already used by `local-composer` and `tools-composer`).
+- Consumes: `secrets.PAT_TOKEN` (repository secret, must be created by the user out-of-band; a fine-grained PAT scoped to this repo with `contents: write` + `pull-requests: write`).
+- Produces: nothing consumed by other tasks — this is the only task in this plan.
+
+- [ ] **Step 1: Write the workflow file**
+
+```yaml
+name: Composer Updates
+
+on:
+  schedule:
+    - cron: '17 4 * * *'
+  workflow_dispatch: ~
+
+jobs:
+  composer-updates:
+    name: Update Composer dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Prepare PHP
+        uses: ./.github/actions/local-php
+
+      - name: Update main app dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=./
+
+      - name: Update deptrac dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/deptrac
+
+      - name: Update infection dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/infection
+
+      - name: Update jsonlint dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/jsonlint
+
+      - name: Update php-cs-fixer dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/php-cs-fixer
+
+      - name: Update phpmd dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/phpmd
+
+      - name: Update phpstan dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/phpstan
+
+      - name: Update psalm dependencies
+        run: composer update --bump-after-update --with-all-dependencies --optimize-autoloader --working-dir=tools/psalm
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          branch: chore/composer-updates
+          delete-branch: true
+          commit-message: "Composers updates"
+          title: "Composers updates"
+          labels: dependencies
+```
+
+- [ ] **Step 2: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/composer_updates.yml'))" && echo OK`
+Expected: `OK` (no exception)
+
+- [ ] **Step 3: Cross-check against the Makefile's `updates` target**
+
+Run: `grep -A10 '^updates:' Makefile`
+Expected: the 8 `--working-dir` values (`./`, `tools/deptrac`, `tools/infection`, `tools/jsonlint`, `tools/php-cs-fixer`, `tools/phpmd`, `tools/phpstan`, `tools/psalm`) match exactly, same order, same flags (`--bump-after-update --with-all-dependencies --optimize-autoloader`), as the 8 `run:` steps just written.
+
+- [ ] **Step 4: Cross-check the reused composite action's path**
+
+Run: `test -f .github/actions/local-php/action.yml && echo FOUND`
+Expected: `FOUND` — confirms the `uses: ./.github/actions/local-php` reference in the new workflow resolves to a real action.
+
+- [ ] **Step 5: Stage the new file (do not commit)**
+
+```bash
+git add .github/workflows/composer_updates.yml
+git status --short
+```
+
+Expected: `A  .github/workflows/composer_updates.yml` shown as staged. Do **not** run `git commit` — per the user's standing instruction, commits happen only when explicitly requested.
+
+---
+
+## Post-merge manual follow-up (not an automated task)
+
+These cannot be executed from within this repo/session and are the user's responsibility:
+
+1. Create a fine-grained GitHub PAT scoped to `douzeEnsemble/pokenini-api` with `contents: write` and `pull-requests: write`, and add it as the repository secret `PAT_TOKEN` (Settings → Secrets and variables → Actions).
+2. After merging this workflow to `main`, trigger one `workflow_dispatch` run manually (Actions tab) to confirm a PR gets opened against `chore/composer-updates` and that it correctly triggers `ci_codequality`, `ci_tests`, and `security`.

--- a/docs/superpowers/specs/2026-07-12-composer-updates-automation-design.md
+++ b/docs/superpowers/specs/2026-07-12-composer-updates-automation-design.md
@@ -1,0 +1,92 @@
+# Design: automated Composer updates workflow
+
+## Purpose
+
+Automate what `make updates` does locally (bump every Composer dependency across the
+main app and the 6 quality-tool sub-projects) via GitHub Actions, on a daily schedule,
+opening/updating a pull request — a personal equivalent of Dependabot.
+
+## Non-goals
+
+- No per-tool/per-package PR splitting (Dependabot-style). One bundled PR, matching the
+  historical manual workflow (see commits like `7616b28 Composers updates`).
+- No change to the existing `ci_codequality.yml` / `ci_tests.yml` / `security.yml`
+  workflows beyond the fact that they will now also run against the auto-generated PR
+  (they already trigger on `pull_request: ~`).
+- No Docker/DB/Moco stack involved — `composer update` needs only PHP + Composer.
+
+## Trigger
+
+New workflow file: `.github/workflows/composer_updates.yml`
+
+- `schedule`: daily cron, `17 4 * * *` (04:17 UTC, off-the-hour to avoid GitHub Actions
+  congestion).
+- `workflow_dispatch`: allows a manual run on demand.
+
+## Job
+
+Single job `composer-updates` on `ubuntu-latest`.
+
+1. **Checkout** — plain `actions/checkout@v6` with the default `GITHUB_TOKEN` (no
+   `PAT_TOKEN`). The PAT is deliberately kept off this step: it would otherwise sit as a
+   persisted git credential for the rest of the job, during which every `composer update`
+   step executes third-party package/plugin code — needlessly widening what a compromised
+   dependency could exfiltrate. The PAT is only actually required on the PR-creation step
+   below (see step 4), since that's what authenticates the push/PR and is what determines
+   whether the PR triggers other workflows (anti-recursion protection: GitHub refuses to
+   let a `GITHUB_TOKEN`-authored push/PR trigger other workflows, and we need the PR to
+   trigger `ci_codequality`, `ci_tests`, and `security` normally).
+2. **PHP setup** — reuse `./.github/actions/local-php` (already used by
+   `local-composer`/`tools-composer`). It copies `.env.ci` to `.env` and installs PHP 8.5
+   with the extension set already validated by existing CI jobs. No Docker compose stack
+   is started.
+3. **Composer updates** — one step per directory, run in the same order as the `updates`
+   Makefile target, each `composer update --bump-after-update --with-all-dependencies
+   --optimize-autoloader`:
+   - main app (`--working-dir=./`)
+   - `tools/deptrac`
+   - `tools/infection`
+   - `tools/jsonlint`
+   - `tools/php-cs-fixer`
+   - `tools/phpmd`
+   - `tools/phpstan`
+   - `tools/psalm`
+
+   Any step failing fails the job (default shell behavior) — no partial/broken PR is
+   created in that case.
+4. **Open/update PR** — `peter-evans/create-pull-request@v7`:
+   - `token: ${{ secrets.PAT_TOKEN }}`
+   - `branch: chore/composer-updates` (fixed name, so subsequent daily runs update the
+     same branch/PR instead of piling up new ones)
+   - `delete-branch: true` (branch is cleaned up once the PR is merged/closed)
+   - `commit-message` / `title`: `Composers updates`
+   - `labels: dependencies` (existing repo label)
+   - No explicit diff-check needed: the action itself no-ops (no branch push, no PR) when
+     there is no diff to commit.
+
+**Hardening:** top-level `permissions: contents: read` (the default `GITHUB_TOKEN` is
+unused for writes since all pushes/PR operations go through `PAT_TOKEN`) and a
+`concurrency` group (`composer-updates`, `cancel-in-progress: true`) so an ad-hoc
+`workflow_dispatch` run can't race the daily `schedule` run over the same
+`chore/composer-updates` branch.
+
+## Secrets
+
+- `PAT_TOKEN` (already agreed): a fine-grained Personal Access Token scoped to this repo
+  only, with `contents: write` and `pull-requests: write` permissions. Must be added as a
+  repository secret before the workflow can push/open PRs. This is a manual, one-time
+  action item outside the scope of the code change itself.
+
+## Failure handling
+
+- A `composer update` failure (e.g. dependency conflict) fails the whole job; standard
+  GitHub Actions failure notification (email) is the signal — no extra alerting needed.
+- No changes → no branch push → no PR → no notification (silent no-op), same as
+  Dependabot's behavior on a no-op day.
+
+## Testing / validation
+
+This is a CI-only change with no PHP application code involved — validation is a
+`workflow_dispatch` manual run after merge (and confirming a PR gets opened/updated and
+that its checks run correctly), plus reviewing the workflow YAML against the existing
+composite actions it reuses (`local-php`).


### PR DESCRIPTION
## Summary
- New `.github/workflows/composer_updates.yml`: runs the 8 `composer update --bump-after-update` calls from the `updates` Makefile target (main app + deptrac, infection, jsonlint, php-cs-fixer, phpmd, phpstan, psalm) on a daily cron (`17 4 * * *`) plus `workflow_dispatch`, then opens/updates a single PR via `peter-evans/create-pull-request@v7` on a fixed `chore/composer-updates` branch — a personal Dependabot.
- Reuses the existing `./.github/actions/local-php` composite action (no Docker stack needed for `composer update`).
- PAT (`secrets.PAT_TOKEN`) is used only on the PR-creation step (not on checkout), so the auto-generated PR actually triggers `ci_codequality`/`ci_tests`/`security` (which listen on `pull_request: ~`) without unnecessarily exposing the token to the third-party plugin/script code that `composer update` executes.
- Design spec and implementation plan included under `docs/superpowers/`.

## Setup required before this can run
- Add a fine-grained PAT scoped to this repo (`contents: write` + `pull-requests: write`) as the repository secret `PAT_TOKEN`.

## Test plan
- [x] YAML syntax validated
- [x] 8 `composer update` steps cross-checked against the Makefile's `updates:` target (same working-dirs, same order, same flags)
- [x] `./.github/actions/local-php` reference confirmed to resolve
- [ ] After merge: trigger one manual `workflow_dispatch` run to confirm a PR opens against `chore/composer-updates` and correctly triggers downstream CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)