### PR TITLE
Run pending Doctrine migrations on prod container start

### DIFF
--- a/.docker/php/docker-entrypoint-prod.sh
+++ b/.docker/php/docker-entrypoint-prod.sh
@@ -8,4 +8,11 @@ set -e
 # Resync explicitly from the golden copy baked into the image on every start.
 rsync -a --delete /app/public-src/ /app/public/
 
+# RUN_MIGRATIONS is set on the `php` service only (not `worker`), so a
+# deploy runs pending Doctrine migrations exactly once even though the
+# same image backs several Swarm services with no shared migration lock.
+if [ "${RUN_MIGRATIONS:-}" = "true" ]; then
+	php bin/console doctrine:migrations:migrate --no-interaction
+fi
+
 exec docker-php-entrypoint "$@"


### PR DESCRIPTION
## Summary
- The original api-platform boilerplate entrypoint ran `doctrine:migrations:migrate` on every container start; it was dropped during the 2024 Docker stack rewrite (`New stack docker`) and never reintroduced.
- Migrations merged since then (e.g. `Version20260715055322` for `ImagePipelineRun`) have never actually run in prod/staging.
- Reintroduces the migration step in `.docker/php/docker-entrypoint-prod.sh`, gated behind a `RUN_MIGRATIONS` env var so it only fires on the `php` service — `worker` boots from the same image/entrypoint and would otherwise race it on every deploy with no shared Doctrine lock.
- Companion infra PR sets `RUN_MIGRATIONS=true` on the `php` service in `pi-projects` (prod + staging compose files).

## Test plan
- [ ] Deploy to staging with the companion `pi-projects` PR and confirm `doctrine_migration_versions` picks up `Version20260715055322` after the container starts
- [ ] Confirm `worker` container does not attempt to run migrations (no `RUN_MIGRATIONS` set there)
- [ ] Confirm nginx/public asset rsync step still runs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015PqdNWhrGiquFmWzNqkB4B