### PR TITLE
Widen image_pipeline_run workflow run id columns to BIGINT

### DIFF
--- a/migrations/2026/07/Version20260729062543.php
+++ b/migrations/2026/07/Version20260729062543.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260729062543 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Widen image_pipeline_run.workflow_arun_id/workflow_brun_id from INT to BIGINT: GitHub Actions run ids now exceed the 32-bit integer range';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE image_pipeline_run ALTER workflow_arun_id TYPE BIGINT');
+        $this->addSql('ALTER TABLE image_pipeline_run ALTER workflow_brun_id TYPE BIGINT');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE image_pipeline_run ALTER workflow_arun_id TYPE INT');
+        $this->addSql('ALTER TABLE image_pipeline_run ALTER workflow_brun_id TYPE INT');
+    }
+}

--- a/src/Entity/ImagePipelineRun.php
+++ b/src/Entity/ImagePipelineRun.php
@@ -25,7 +25,7 @@ final class ImagePipelineRun
     #[ORM\Column(type: Types::DATETIME_MUTABLE)]
     public \DateTime $updatedAt;
 
-    #[ORM\Column(nullable: true)]
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
     public ?int $workflowARunId = null;
 
     #[ORM\Column(nullable: true)]
@@ -49,7 +49,7 @@ final class ImagePipelineRun
     #[ORM\Column(nullable: true)]
     public ?string $iconPrMergeCommitSha = null;
 
-    #[ORM\Column(nullable: true)]
+    #[ORM\Column(type: Types::BIGINT, nullable: true)]
     public ?int $workflowBRunId = null;
 
     #[ORM\Column(nullable: true)]


### PR DESCRIPTION
## Summary
- GitHub Actions run ids are a single global, ever-increasing counter across all of GitHub and have now exceeded 2^31, so persisting `workflow_arun_id`/`workflow_brun_id` on `image_pipeline_run` fails in production with `SQLSTATE[22003]: Numeric value out of range` on every refresh of the `update_images` admin action.
- Widen `ImagePipelineRun::$workflowARunId` / `$workflowBRunId` to `Types::BIGINT` and add a migration (`ALTER ... TYPE BIGINT`) to match.

## Test plan
- [x] `make sf c="doctrine:migration:migrate"` applies cleanly
- [x] `doctrine:schema:update --dump-sql` shows no remaining drift on `image_pipeline_run` after migrating
- [x] `ImagePipelineRunRepositoryTest` / `ImagePipelineRunControllerTest` pass
- [x] Full suite: 1198 tests, 100% coverage
- [x] `make code-quality` (phpstan, psalm, phpmd, cs-fixer, deptrac, ...) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfyhAy1W8PuQ8QX9gUBCFg