### PR TITLE
Fix memory leak in dex availabilities calculation (unbounded ExpressionLanguage cache)

### DIFF
--- a/src/Calculator/DexAvailabilityCalculator.php
+++ b/src/Calculator/DexAvailabilityCalculator.php
@@ -20,6 +20,8 @@ class DexAvailabilityCalculator
 
     public function calculate(Dex $dex): int
     {
+        $this->dexPokemonAvailabilityCalculator->resetExpressionLanguageCache();
+
         $count = 0;
         $batchCount = 0;
         $dexId = $dex->getIdentifier();

--- a/src/Calculator/DexPokemonAvailabilityCalculator.php
+++ b/src/Calculator/DexPokemonAvailabilityCalculator.php
@@ -16,7 +16,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class DexPokemonAvailabilityCalculator
 {
-    private readonly ExpressionLanguage $expressionLanguage;
+    private ExpressionLanguage $expressionLanguage;
 
     public function __construct(
         private readonly GameBundlesAvailabilitiesService $gameBundlesAvailabilitiesService,
@@ -25,6 +25,17 @@ class DexPokemonAvailabilityCalculator
         private readonly GamesShiniesAvailabilitiesService $gamesShiniesAvailabilitiesService,
         private readonly CollectionsAvailabilitiesService $collectionsAvailabilitiesService,
     ) {
+        $this->expressionLanguage = new ExpressionLanguage();
+    }
+
+    /**
+     * ExpressionLanguage caches every parsed rule forever in memory (no cache
+     * pool given = ArrayAdapter with no eviction). Since each Dex has its own
+     * (potentially very large) selectionRule, that cache must be dropped
+     * between dexes or it grows unbounded across a full recalculation run.
+     */
+    public function resetExpressionLanguageCache(): void
+    {
         $this->expressionLanguage = new ExpressionLanguage();
     }
 

--- a/tests/src/Unit/Calculator/DexAvailabilityCalculatorTest.php
+++ b/tests/src/Unit/Calculator/DexAvailabilityCalculatorTest.php
@@ -63,6 +63,10 @@ final class DexAvailabilityCalculatorTest extends TestCase
 
         $dexPokemonAvailabilityCalculator = $this->createMock(DexPokemonAvailabilityCalculator::class);
         $dexPokemonAvailabilityCalculator
+            ->expects($this->once())
+            ->method('resetExpressionLanguageCache')
+        ;
+        $dexPokemonAvailabilityCalculator
             ->expects($this->exactly(3))
             ->method('calculate')
             ->willReturnOnConsecutiveCalls(
@@ -123,6 +127,10 @@ final class DexAvailabilityCalculatorTest extends TestCase
         ;
 
         $dexPokemonAvailabilityCalculator = $this->createMock(DexPokemonAvailabilityCalculator::class);
+        $dexPokemonAvailabilityCalculator
+            ->expects($this->exactly(2))
+            ->method('resetExpressionLanguageCache')
+        ;
         $dexPokemonAvailabilityCalculator
             ->expects($this->exactly(6))
             ->method('calculate')

--- a/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorTest.php
+++ b/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorTest.php
@@ -16,6 +16,7 @@ use App\Service\GamesAvailabilitiesService;
 use App\Service\GamesShiniesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 /**
  * @internal
@@ -23,6 +24,29 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexPokemonAvailabilityCalculator::class)]
 final class DexPokemonAvailabilityCalculatorTest extends TestCase
 {
+    public function testResetExpressionLanguageCacheReplacesTheInstance(): void
+    {
+        $calculator = new DexPokemonAvailabilityCalculator(
+            $this->createMock(GameBundlesAvailabilitiesService::class),
+            $this->createMock(GameBundlesShiniesAvailabilitiesService::class),
+            $this->createMock(GamesAvailabilitiesService::class),
+            $this->createMock(GamesShiniesAvailabilitiesService::class),
+            $this->createMock(CollectionsAvailabilitiesService::class),
+        );
+
+        $property = new \ReflectionProperty(DexPokemonAvailabilityCalculator::class, 'expressionLanguage');
+
+        /** @var ExpressionLanguage $before */
+        $before = $property->getValue($calculator);
+
+        $calculator->resetExpressionLanguageCache();
+
+        /** @var ExpressionLanguage $after */
+        $after = $property->getValue($calculator);
+
+        $this->assertNotSame($before, $after);
+    }
+
     public function testCalculateNotAvailable(): void
     {
         $pokemon = new Pokemon();


### PR DESCRIPTION
## Summary
- `DexPokemonAvailabilityCalculator` reused a single `ExpressionLanguage` instance across the whole `app:calculate:dex_availabilities` batch job. With no cache pool given, `ExpressionLanguage` falls back to an in-memory `ArrayAdapter` that never evicts, so every distinct `Dex::$selectionRule` parsed stayed cached for the entire run.
- This caused the "Allowed memory size exhausted" fatal reported on the prod Messenger worker for `calculate_dex_availabilities`, growing as the number of distinct dex rules increases.
- Fix: reset the `ExpressionLanguage` instance once per dex (`DexAvailabilityCalculator::calculate()`), so the cache still speeds up evaluation across a dex's pokemon set but never accumulates across dexes.

## Test plan
- [x] Added `DexPokemonAvailabilityCalculatorTest::testResetExpressionLanguageCacheReplacesTheInstance` verifying the reset actually replaces the cached instance.
- [x] Updated `DexAvailabilityCalculatorTest` to assert `resetExpressionLanguageCache()` is called once per `calculate($dex)` invocation.
- [ ] `make tests` / `make coverage` / `make infection` (not run in this session — please run before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4DYnA9WLNfaVP8Mg81pYZ