### PR TITLE
Add GET /version endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ tools/*/var
 /docker-compose.override.yaml
 
 /.superpowers/
+/.worktrees/

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -9,7 +9,8 @@ services:
             int $eloDDifference: '%env(ELO_D_DIFFERENCE)%'
             int $eloDefault: '%env(ELO_DEFAULT)%'
             string $sqlDir: '%kernel.project_dir%/resources/sql'
-            
+            string $metadataDir: '%kernel.project_dir%/resources/metadata'
+
     App\:
         resource: '../src/'
         exclude:

--- a/doc/endpoints.md
+++ b/doc/endpoints.md
@@ -54,6 +54,7 @@ curl -u web:douze http://web:8080/types
 | 31 | GET | `/debogage/pokemon/{slug}` | (Debug) Détail brut d'un pokémon |
 | 32 | GET | `/debogage/pokemon/{slug}/availabilities` | (Debug) Disponibilités d'un pokémon |
 | 33 | DELETE | `/debogage/pokemon/{slug}/caches` | (Debug) Purge des caches de disponibilités d'un pokémon |
+| 34 | GET | `/version` | Version de l'application |
 
 > **Note** : le préfixe d'administration est littéralement `/istration` (et non `/administration`), et le préfixe de debug est `/debogage`.
 
@@ -1262,3 +1263,27 @@ curl -u web:douze -X DELETE http://web:8080/debogage/pokemon/venusaur-mega/cache
 Exemple de réponse (`200`) : corps vide.
 
 Codes de statut : `200`, `401`, `404`.
+
+---
+
+### 34. GET `/version`
+
+Renvoie le numéro de version de l'application actuellement déployée, lu depuis le fichier `resources/metadata/version`. Si le fichier est absent ou illisible, la réponse contient `"unknown"`.
+
+**Paramètres** : aucun.
+
+Exemple de requête :
+
+```bash
+curl -u web:douze http://web:8080/version
+```
+
+Exemple de réponse (`200`) :
+
+```json
+{
+  "version": "1.2.12"
+}
+```
+
+Codes de statut : `200`, `401`.

--- a/src/Controller/VersionController.php
+++ b/src/Controller/VersionController.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\DTO\Response\VersionResponse;
+use App\Service\VersionService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpKernel\Attribute\Serialize;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route('/version')]
+final class VersionController extends AbstractController
+{
+    #[Route(path: '', methods: ['GET'])]
+    #[Serialize]
+    public function get(VersionService $service): VersionResponse
+    {
+        return new VersionResponse($service->getVersion());
+    }
+}

--- a/src/DTO/Response/VersionResponse.php
+++ b/src/DTO/Response/VersionResponse.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Response;
+
+final class VersionResponse
+{
+    public function __construct(
+        public readonly string $version,
+    ) {}
+}

--- a/src/Service/VersionService.php
+++ b/src/Service/VersionService.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+class VersionService
+{
+    private const string FALLBACK_VERSION = 'unknown';
+
+    public function __construct(private readonly string $metadataDir) {}
+
+    public function getVersion(): string
+    {
+        $path = $this->metadataDir.'/version';
+
+        if (!is_file($path)) {
+            return self::FALLBACK_VERSION;
+        }
+
+        return trim((string) file_get_contents($path));
+    }
+}

--- a/src/Service/VersionService.php
+++ b/src/Service/VersionService.php
@@ -14,7 +14,7 @@ class VersionService
     {
         $path = $this->metadataDir.'/version';
 
-        if (!is_file($path)) {
+        if (!is_readable($path)) {
             return self::FALLBACK_VERSION;
         }
 

--- a/tests/src/Integration/Controller/VersionControllerTest.php
+++ b/tests/src/Integration/Controller/VersionControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Controller;
+
+use App\Controller\VersionController;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(VersionController::class)]
+final class VersionControllerTest extends WebTestCase
+{
+    #[Test]
+    public function getReturnsSuccessfulJsonResponse(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/version', [], [], [
+            'PHP_AUTH_USER' => 'web',
+            'PHP_AUTH_PW' => 'douze',
+        ]);
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('content-type', 'application/json');
+    }
+
+    #[Test]
+    public function getReturnsVersionFromMetadataFile(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/version', [], [], [
+            'PHP_AUTH_USER' => 'web',
+            'PHP_AUTH_PW' => 'douze',
+        ]);
+
+        $content = $client->getResponse()->getContent();
+        self::assertIsString($content);
+
+        $expectedVersion = trim((string) file_get_contents(dirname(__DIR__, 4).'/resources/metadata/version'));
+
+        self::assertJsonStringEqualsJsonString(
+            json_encode(['version' => $expectedVersion], JSON_THROW_ON_ERROR),
+            $content,
+        );
+    }
+
+    #[Test]
+    public function getNonAuthenticatedReturns401(): void
+    {
+        $client = self::createClient();
+        $client->request('GET', '/version');
+
+        self::assertResponseStatusCodeSame(401);
+    }
+}

--- a/tests/src/Unit/Service/VersionServiceTest.php
+++ b/tests/src/Unit/Service/VersionServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\VersionService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+#[CoversClass(VersionService::class)]
+final class VersionServiceTest extends TestCase
+{
+    private string $tempDir;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir().'/version_service_test_'.uniqid();
+        mkdir($this->tempDir);
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        $files = glob($this->tempDir.'/*');
+        if (false !== $files) {
+            foreach ($files as $file) {
+                unlink($file);
+            }
+        }
+        rmdir($this->tempDir);
+    }
+
+    public function testGetVersionReturnsTrimmedFileContent(): void
+    {
+        file_put_contents($this->tempDir.'/version', "1.2.12\n");
+        $service = new VersionService($this->tempDir);
+
+        $this->assertSame('1.2.12', $service->getVersion());
+    }
+
+    public function testGetVersionReturnsFallbackWhenFileMissing(): void
+    {
+        $service = new VersionService($this->tempDir);
+
+        $this->assertSame('unknown', $service->getVersion());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a small `VersionService` that reads this repo's local `resources/metadata/version` file.
- Exposes it as `GET /version` (`VersionController` + `VersionResponse` DTO), gated by the existing global `ROLE_API` HTTP Basic access control — no security config change.
- Adds a `GET /version` entry to `doc/endpoints.md`.

This is the first of three linked PRs (pokenini-api → pokenini-back → pokenini-web) implementing an admin "Versions" tab in pokenini-web that shows the deployed version of all four Pokénini bricks (web, back, api, resources).

## Test plan
- [x] Unit tests for `VersionService` (trimmed content, missing-file fallback)
- [x] Integration tests for `VersionController` (200 + content-type, version matches metadata file, 401 unauthenticated)
- [x] `make code-quality` clean (aside from a pre-existing, unrelated `editorconfig-linter`/vendor issue)
- [x] `make measures`: 100% coverage, 100% MSI

🤖 Generated with [Claude Code](https://claude.com/claude-code)