### PR TITLE
Add updated_at to the /version endpoint

### DIFF
--- a/src/Controller/VersionController.php
+++ b/src/Controller/VersionController.php
@@ -17,6 +17,6 @@ final class VersionController extends AbstractController
     #[Serialize]
     public function get(VersionService $service): VersionResponse
     {
-        return new VersionResponse($service->getVersion());
+        return new VersionResponse($service->getVersion(), $service->getUpdatedAt());
     }
 }

--- a/src/DTO/Response/VersionResponse.php
+++ b/src/DTO/Response/VersionResponse.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App\DTO\Response;
 
+use Symfony\Component\Serializer\Attribute\SerializedName;
+
 final class VersionResponse
 {
     public function __construct(
         public readonly string $version,
+        #[SerializedName('updated_at')]
+        public readonly ?\DateTimeImmutable $updatedAt,
     ) {}
 }

--- a/src/Service/VersionService.php
+++ b/src/Service/VersionService.php
@@ -20,4 +20,21 @@ class VersionService
 
         return trim((string) file_get_contents($path));
     }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        $path = $this->metadataDir.'/version';
+
+        if (!is_readable($path)) {
+            return null;
+        }
+
+        $mtime = filemtime($path);
+
+        if (false === $mtime) {
+            return null;
+        }
+
+        return (new \DateTimeImmutable())->setTimestamp($mtime);
+    }
 }

--- a/tests/src/Integration/Controller/VersionControllerTest.php
+++ b/tests/src/Integration/Controller/VersionControllerTest.php
@@ -40,10 +40,15 @@ final class VersionControllerTest extends WebTestCase
         $content = $client->getResponse()->getContent();
         self::assertIsString($content);
 
-        $expectedVersion = trim((string) file_get_contents(dirname(__DIR__, 4).'/resources/metadata/version'));
+        $versionFilePath = dirname(__DIR__, 4).'/resources/metadata/version';
+        $expectedVersion = trim((string) file_get_contents($versionFilePath));
+        $expectedUpdatedAt = (new \DateTimeImmutable())->setTimestamp((int) filemtime($versionFilePath));
 
         self::assertJsonStringEqualsJsonString(
-            json_encode(['version' => $expectedVersion], JSON_THROW_ON_ERROR),
+            json_encode([
+                'version' => $expectedVersion,
+                'updated_at' => $expectedUpdatedAt->format(\DateTimeInterface::ATOM),
+            ], JSON_THROW_ON_ERROR),
             $content,
         );
     }

--- a/tests/src/Unit/Service/VersionServiceTest.php
+++ b/tests/src/Unit/Service/VersionServiceTest.php
@@ -49,4 +49,20 @@ final class VersionServiceTest extends TestCase
 
         $this->assertSame('unknown', $service->getVersion());
     }
+
+    public function testGetUpdatedAtReturnsFileMtime(): void
+    {
+        file_put_contents($this->tempDir.'/version', "1.2.12\n");
+        $expectedMtime = filemtime($this->tempDir.'/version');
+        $service = new VersionService($this->tempDir);
+
+        $this->assertSame($expectedMtime, $service->getUpdatedAt()?->getTimestamp());
+    }
+
+    public function testGetUpdatedAtReturnsNullWhenFileMissing(): void
+    {
+        $service = new VersionService($this->tempDir);
+
+        $this->assertNull($service->getUpdatedAt());
+    }
 }


### PR DESCRIPTION
## Summary
- `VersionService` now exposes `getUpdatedAt(): ?\DateTimeImmutable`, built from the same `filemtime()` already used for the version file.
- `GET /version` now returns `{"version": "...", "updated_at": "..."}` instead of just the version string.

Follow-up to #338 — pokenini-web's admin Versions tab wants to show when each brick was last deployed, not just its version.

## Test plan
- [ ] `docker compose exec php vendor/bin/phpunit tests/src/Unit tests/src/Integration`
- [ ] `make code-quality`
- [ ] `make measures` (100% coverage / MSI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)