### PR TITLE
ci: add EditorConfig linter to code quality workflow

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,5 @@
+{
+    "Exclude": [
+        "tools/.*/.*\\.phar$"
+    ]
+}

--- a/.github/workflows/ci_codequality.yml
+++ b/.github/workflows/ci_codequality.yml
@@ -20,6 +20,15 @@ env:
   PHP_CS_FIXER_IGNORE_ENV: 1
 
 jobs:
+  editorconfig:
+    name: EditorConfig
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run
+        run: docker run --rm --volume=$PWD:/check mstruebing/editorconfig-checker:v3.6.0 editorconfig-checker --exclude=".phar"
+
   phpcsfixer:
     name: PHP-CS-Fixer
     runs-on: ubuntu-latest

--- a/docs/superpowers/specs/mockups/2026-08-03-pokedex-link/offcanvas-links-section.html
+++ b/docs/superpowers/specs/mockups/2026-08-03-pokedex-link/offcanvas-links-section.html
@@ -39,7 +39,7 @@
         <i class="bi bi-share"></i>
       </a>
       <a class="list-group-item list-group-item-action list-group-item-info open-offcanvas"
-         href="#offcanvas" title="Ouvrir le panneau" data-bs-toggle="offcanvas">
+        href="#offcanvas" title="Ouvrir le panneau" data-bs-toggle="offcanvas">
         <i class="bi bi-three-dots"></i>
       </a>
     </div>


### PR DESCRIPTION
## Summary
- Adds `.editorconfig-checker.json` and a new `editorconfig` job to `ci_codequality.yml`, running the existing `EDITORCONFIG_LINTER_CMD` (already wired into `make code-quality`) in CI.

## Test plan
- [ ] CI passes on this PR (the new `editorconfig` job)