### PR TITLE
chore(tests): migrate to #[Test] attribute

### DIFF
--- a/tests/src/Integration/Command/CalculateDexAvailabilitiesCommandTest.php
+++ b/tests/src/Integration/Command/CalculateDexAvailabilitiesCommandTest.php
@@ -19,6 +19,7 @@ use App\Tests\Common\Traits\CounterTrait\CountPokemonTrait;
 use App\Tests\Common\Traits\HasserTrait\HasDexAvailabilityTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -38,7 +39,8 @@ final class CalculateDexAvailabilitiesCommandTest extends AbstractTestCaseComman
     use HasDexAvailabilityTrait;
     use CountActionLogTrait;
 
-    public function testNoDexAvailabilities(): void
+    #[Test]
+    public function noDexAvailabilities(): void
     {
         $repo = self::getContainer()->get(PokemonsRepository::class);
         $queryBuilder = $repo->createQueryBuilder('p')
@@ -68,7 +70,8 @@ final class CalculateDexAvailabilitiesCommandTest extends AbstractTestCaseComman
         $this->assertEquals($initialDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testDexAvailabilities(): void
+    #[Test]
+    public function dexAvailabilities(): void
     {
         $this->assertEquals(70, $this->getDexAvailabilityCount());
 

--- a/tests/src/Integration/Command/CalculateGameBundlesAvailabilitiesCommandTest.php
+++ b/tests/src/Integration/Command/CalculateGameBundlesAvailabilitiesCommandTest.php
@@ -18,6 +18,7 @@ use App\Tests\Common\Traits\CounterTrait\CountGameAvailabilityTrait;
 use App\Tests\Common\Traits\CounterTrait\CountGameBundleAvailabilityTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -36,7 +37,8 @@ final class CalculateGameBundlesAvailabilitiesCommandTest extends AbstractTestCa
     use CountGameBundleAvailabilityTrait;
     use CountActionLogTrait;
 
-    public function testNoGamesAvailabilities(): void
+    #[Test]
+    public function noGamesAvailabilities(): void
     {
         $repo = self::getContainer()->get(GamesAvailabilitiesRepository::class);
         $queryBuilder = $repo->createQueryBuilder('ga')
@@ -58,7 +60,8 @@ final class CalculateGameBundlesAvailabilitiesCommandTest extends AbstractTestCa
         $this->assertStringContainsString("0 bundles' availabilities calculated", $commandTester->getDisplay());
     }
 
-    public function testCalculateBundlesAvailabilities(): void
+    #[Test]
+    public function calculateBundlesAvailabilities(): void
     {
         $initialToProcessCount = $this->getActionLogToProcessCount();
         $initialDoneCount = $this->getActionLogDoneCount();

--- a/tests/src/Integration/Command/CalculateGameBundlesShiniesAvailabilitiesCommandTest.php
+++ b/tests/src/Integration/Command/CalculateGameBundlesShiniesAvailabilitiesCommandTest.php
@@ -19,6 +19,7 @@ use App\Tests\Common\Traits\CounterTrait\CountGameBundleShinyAvailabilityTrait;
 use App\Tests\Common\Traits\CounterTrait\CountGameShinyAvailabilityTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -38,7 +39,8 @@ final class CalculateGameBundlesShiniesAvailabilitiesCommandTest extends Abstrac
     use CountGameBundleShinyAvailabilityTrait;
     use CountActionLogTrait;
 
-    public function testNoGamesShiniesAvailabilities(): void
+    #[Test]
+    public function noGamesShiniesAvailabilities(): void
     {
         $repo = self::getContainer()->get(GamesShiniesAvailabilitiesRepository::class);
         $queryBuilder = $repo->createQueryBuilder('gsa')
@@ -63,7 +65,8 @@ final class CalculateGameBundlesShiniesAvailabilitiesCommandTest extends Abstrac
         );
     }
 
-    public function testCalculateBundlesShiniesAvailabilities(): void
+    #[Test]
+    public function calculateBundlesShiniesAvailabilities(): void
     {
         $initialToProcessCount = $this->getActionLogToProcessCount();
         $initialDoneCount = $this->getActionLogDoneCount();

--- a/tests/src/Integration/Command/CalculatePokemonAvailabilitiesCommandTest.php
+++ b/tests/src/Integration/Command/CalculatePokemonAvailabilitiesCommandTest.php
@@ -19,6 +19,7 @@ use App\Tests\Common\Traits\CounterTrait\CountPokemonTrait;
 use App\Tests\Common\Traits\HasserTrait\HasPokemonAvailabilitiesTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -38,7 +39,8 @@ final class CalculatePokemonAvailabilitiesCommandTest extends AbstractTestCaseCo
     use HasPokemonAvailabilitiesTrait;
     use CountActionLogTrait;
 
-    public function testNoPokemonAvailabilities(): void
+    #[Test]
+    public function noPokemonAvailabilities(): void
     {
         $repo = self::getContainer()->get(PokemonsRepository::class);
         $queryBuilder = $repo->createQueryBuilder('p')
@@ -77,7 +79,8 @@ final class CalculatePokemonAvailabilitiesCommandTest extends AbstractTestCaseCo
         $this->assertEquals($initialDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testPokemonAvailabilities(): void
+    #[Test]
+    public function pokemonAvailabilities(): void
     {
         $this->assertEquals(26, $this->getPokemonAvailabilitiesCount('game_bundle'));
         $this->assertEquals(26, $this->getPokemonAvailabilitiesCount('game_bundle_shiny'));

--- a/tests/src/Integration/Command/UpdateCollectionsAvailabilitiesCommandTest.php
+++ b/tests/src/Integration/Command/UpdateCollectionsAvailabilitiesCommandTest.php
@@ -15,6 +15,7 @@ use App\Tests\Common\Traits\CounterTrait\CountActionLogTrait;
 use App\Tests\Common\Traits\CounterTrait\CountCollectionAvailabilityTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -31,7 +32,8 @@ final class UpdateCollectionsAvailabilitiesCommandTest extends AbstractTestCaseC
     use CountCollectionAvailabilityTrait;
     use CountActionLogTrait;
 
-    public function testUpdate(): void
+    #[Test]
+    public function update(): void
     {
         $this->assertGreaterThan(0, $this->getCollectionAvailabilityCount());
 

--- a/tests/src/Integration/Command/UpdateGamesAvailabilitiesCommandTest.php
+++ b/tests/src/Integration/Command/UpdateGamesAvailabilitiesCommandTest.php
@@ -15,6 +15,7 @@ use App\Tests\Common\Traits\CounterTrait\CountActionLogTrait;
 use App\Tests\Common\Traits\CounterTrait\CountGameAvailabilityTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -31,7 +32,8 @@ final class UpdateGamesAvailabilitiesCommandTest extends AbstractTestCaseCommand
     use CountGameAvailabilityTrait;
     use CountActionLogTrait;
 
-    public function testUpdate(): void
+    #[Test]
+    public function update(): void
     {
         $this->assertGreaterThan(0, $this->getGameAvailabilityCount());
 

--- a/tests/src/Integration/Command/UpdateGamesCollectionsAndDexCommandTest.php
+++ b/tests/src/Integration/Command/UpdateGamesCollectionsAndDexCommandTest.php
@@ -15,6 +15,7 @@ use App\Tests\Common\Traits\CounterTrait\CountActionLogTrait;
 use App\Tests\Common\Traits\CounterTrait\CounterTableTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -31,7 +32,8 @@ final class UpdateGamesCollectionsAndDexCommandTest extends AbstractTestCaseComm
     use CounterTableTrait;
     use CountActionLogTrait;
 
-    public function testUpdate(): void
+    #[Test]
+    public function update(): void
     {
         $this->assertEquals(9, $this->getTableCount('game_generation'));
         $this->assertEquals(19, $this->getTableCount('game_bundle'));

--- a/tests/src/Integration/Command/UpdateGamesShiniesAvailabilitiesCommandTest.php
+++ b/tests/src/Integration/Command/UpdateGamesShiniesAvailabilitiesCommandTest.php
@@ -15,6 +15,7 @@ use App\Tests\Common\Traits\CounterTrait\CountActionLogTrait;
 use App\Tests\Common\Traits\CounterTrait\CountGameShinyAvailabilityTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -31,7 +32,8 @@ final class UpdateGamesShiniesAvailabilitiesCommandTest extends AbstractTestCase
     use CountGameShinyAvailabilityTrait;
     use CountActionLogTrait;
 
-    public function testUpdate(): void
+    #[Test]
+    public function update(): void
     {
         $this->assertGreaterThan(0, $this->getGameShinyAvailabilityCount());
 

--- a/tests/src/Integration/Command/UpdateLabelsCommandTest.php
+++ b/tests/src/Integration/Command/UpdateLabelsCommandTest.php
@@ -15,6 +15,7 @@ use App\Tests\Common\Traits\CounterTrait\CountActionLogTrait;
 use App\Tests\Common\Traits\CounterTrait\CounterTableTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -31,7 +32,8 @@ final class UpdateLabelsCommandTest extends AbstractTestCaseCommand
     use CounterTableTrait;
     use CountActionLogTrait;
 
-    public function testUpdate(): void
+    #[Test]
+    public function update(): void
     {
         $this->assertEquals(5, $this->getTableCount('catch_state'));
         $this->assertEquals(3, $this->getTableCount('category_form'));

--- a/tests/src/Integration/Command/UpdatePokemonsCommandTest.php
+++ b/tests/src/Integration/Command/UpdatePokemonsCommandTest.php
@@ -15,6 +15,7 @@ use App\Tests\Common\Traits\CounterTrait\CountActionLogTrait;
 use App\Tests\Common\Traits\CounterTrait\CounterTableTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -31,7 +32,8 @@ final class UpdatePokemonsCommandTest extends AbstractTestCaseCommand
     use CounterTableTrait;
     use CountActionLogTrait;
 
-    public function testUpdateWithInvalidSheetFailsAndLogsError(): void
+    #[Test]
+    public function updateWithInvalidSheetFailsAndLogsError(): void
     {
         $initialErrorCount = $this->getActionLogErrorCount();
 
@@ -42,7 +44,8 @@ final class UpdatePokemonsCommandTest extends AbstractTestCaseCommand
         $this->assertStringContainsString('This is not a valid data spreadsheet', $commandTester->getDisplay());
     }
 
-    public function testUpdate(): void
+    #[Test]
+    public function update(): void
     {
         $this->assertEquals(26, $this->getTableCount('pokemon'));
 

--- a/tests/src/Integration/Command/UpdateRegionalDexNumbersCommandTest.php
+++ b/tests/src/Integration/Command/UpdateRegionalDexNumbersCommandTest.php
@@ -15,6 +15,7 @@ use App\Tests\Common\Traits\CounterTrait\CountActionLogTrait;
 use App\Tests\Common\Traits\CounterTrait\CountRegionalDexNumberTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -31,7 +32,8 @@ final class UpdateRegionalDexNumbersCommandTest extends AbstractTestCaseCommand
     use CountRegionalDexNumberTrait;
     use CountActionLogTrait;
 
-    public function testUpdate(): void
+    #[Test]
+    public function update(): void
     {
         $this->assertGreaterThan(0, $this->getRegionalDexNumberCount());
 

--- a/tests/src/Integration/Controller/AdminCalculateControllerTest.php
+++ b/tests/src/Integration/Controller/AdminCalculateControllerTest.php
@@ -11,6 +11,7 @@ use App\Message\CalculateGameBundlesShiniesAvailabilities;
 use App\Message\CalculatePokemonAvailabilities;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -23,7 +24,8 @@ final class AdminCalculateControllerTest extends WebTestCase
     use RefreshDatabaseTrait;
     use InteractsWithMessenger;
 
-    public function testCalculateGameBundlesAvailabilities(): void
+    #[Test]
+    public function calculateGameBundlesAvailabilities(): void
     {
         $client = self::createClient();
 
@@ -45,7 +47,8 @@ final class AdminCalculateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(CalculateGameBundlesAvailabilities::class, 1);
     }
 
-    public function testCalculateGameBundlesShiniesAvailabilities(): void
+    #[Test]
+    public function calculateGameBundlesShiniesAvailabilities(): void
     {
         $client = self::createClient();
 
@@ -67,7 +70,8 @@ final class AdminCalculateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(CalculateGameBundlesShiniesAvailabilities::class, 1);
     }
 
-    public function testCalculateDexAvailabilities(): void
+    #[Test]
+    public function calculateDexAvailabilities(): void
     {
         $client = self::createClient();
 
@@ -89,7 +93,8 @@ final class AdminCalculateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(CalculateDexAvailabilities::class, 1);
     }
 
-    public function testCalculatePokemonAvailabilities(): void
+    #[Test]
+    public function calculatePokemonAvailabilities(): void
     {
         $client = self::createClient();
 
@@ -111,7 +116,8 @@ final class AdminCalculateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(CalculatePokemonAvailabilities::class, 1);
     }
 
-    public function testUpdateBadAuth(): void
+    #[Test]
+    public function updateBadAuth(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/AdminUpdateControllerTest.php
+++ b/tests/src/Integration/Controller/AdminUpdateControllerTest.php
@@ -14,6 +14,7 @@ use App\Message\UpdatePokemons;
 use App\Message\UpdateRegionalDexNumbers;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -26,7 +27,8 @@ final class AdminUpdateControllerTest extends WebTestCase
     use RefreshDatabaseTrait;
     use InteractsWithMessenger;
 
-    public function testUpdateLabels(): void
+    #[Test]
+    public function updateLabels(): void
     {
         $client = self::createClient();
 
@@ -48,7 +50,8 @@ final class AdminUpdateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(UpdateLabels::class, 1);
     }
 
-    public function testUpdateGamesCollectionsAndDex(): void
+    #[Test]
+    public function updateGamesCollectionsAndDex(): void
     {
         $client = self::createClient();
 
@@ -70,7 +73,8 @@ final class AdminUpdateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(UpdateGamesCollectionsAndDex::class, 1);
     }
 
-    public function testUpdatePokemons(): void
+    #[Test]
+    public function updatePokemons(): void
     {
         $client = self::createClient();
 
@@ -92,7 +96,8 @@ final class AdminUpdateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(UpdatePokemons::class, 1);
     }
 
-    public function testUpdateGamesAvailabilities(): void
+    #[Test]
+    public function updateGamesAvailabilities(): void
     {
         $client = self::createClient();
 
@@ -114,7 +119,8 @@ final class AdminUpdateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(UpdateGamesAvailabilities::class, 1);
     }
 
-    public function testUpdateGamesShiniesAvailabilities(): void
+    #[Test]
+    public function updateGamesShiniesAvailabilities(): void
     {
         $client = self::createClient();
 
@@ -136,7 +142,8 @@ final class AdminUpdateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(UpdateGamesShiniesAvailabilities::class, 1);
     }
 
-    public function testUpdateCollectionsAvailabilities(): void
+    #[Test]
+    public function updateCollectionsAvailabilities(): void
     {
         $client = self::createClient();
 
@@ -158,7 +165,8 @@ final class AdminUpdateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(UpdateCollectionsAvailabilities::class, 1);
     }
 
-    public function testUpdateRegionalDexNumbers(): void
+    #[Test]
+    public function updateRegionalDexNumbers(): void
     {
         $client = self::createClient();
 
@@ -180,7 +188,8 @@ final class AdminUpdateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(UpdateRegionalDexNumbers::class, 1);
     }
 
-    public function testUpdateCollections(): void
+    #[Test]
+    public function updateCollections(): void
     {
         $client = self::createClient();
 
@@ -202,7 +211,8 @@ final class AdminUpdateControllerTest extends WebTestCase
         $this->transport('async')->queue()->assertContains(UpdateCollectionsAvailabilities::class, 1);
     }
 
-    public function testUpdateBadAuth(): void
+    #[Test]
+    public function updateBadAuth(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/AlbumIndexControllerTest.php
+++ b/tests/src/Integration/Controller/AlbumIndexControllerTest.php
@@ -8,6 +8,7 @@ use App\Controller\AlbumIndexController;
 use App\Tests\Common\Data\AlbumData;
 use App\Tests\Common\Traits\ReportTrait\AssertReportTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -22,7 +23,8 @@ final class AlbumIndexControllerTest extends AbstractTestControllerApi
     /**
      * @SuppressWarnings("PHPMD.ExcessiveMethodLength")
      */
-    public function testListUser12RedGreenBlueYellow(): void
+    #[Test]
+    public function listUser12RedGreenBlueYellow(): void
     {
         $this->apiRequest('GET', '/album/7b52009b64fd0a2a49e6d8a939753077792b0554/redgreenblueyellow');
 
@@ -124,7 +126,8 @@ final class AlbumIndexControllerTest extends AbstractTestControllerApi
         $this->assertReport($report, 4, 1, 2, 0, 7);
     }
 
-    public function testListUser12GoldSilverCrystal(): void
+    #[Test]
+    public function listUser12GoldSilverCrystal(): void
     {
         $this->apiRequest('GET', '/album/7b52009b64fd0a2a49e6d8a939753077792b0554/goldsilvercrystal');
 
@@ -206,7 +209,8 @@ final class AlbumIndexControllerTest extends AbstractTestControllerApi
         $this->assertReport($report, 8, 0, 0, 1, 9);
     }
 
-    public function testListUser13(): void
+    #[Test]
+    public function listUser13(): void
     {
         $this->apiRequest('GET', '/album/bd307a3ec329e10a2cff8fb87480823da114f8f4/redgreenblueyellow');
 
@@ -286,7 +290,8 @@ final class AlbumIndexControllerTest extends AbstractTestControllerApi
         $this->assertReport($report, 6, 0, 0, 1, 7);
     }
 
-    public function testListUserUnknown(): void
+    #[Test]
+    public function listUserUnknown(): void
     {
         $this->apiRequest('GET', '/album/46546542313186/redgreenblueyellow');
 
@@ -366,7 +371,8 @@ final class AlbumIndexControllerTest extends AbstractTestControllerApi
         $this->assertReport($report, 0, 0, 0, 0, 7);
     }
 
-    public function testListHome(): void
+    #[Test]
+    public function listHome(): void
     {
         $this->apiRequest('GET', '/album/7b52009b64fd0a2a49e6d8a939753077792b0554/home');
 
@@ -428,7 +434,8 @@ final class AlbumIndexControllerTest extends AbstractTestControllerApi
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testListHomeShiny(): void
+    #[Test]
+    public function listHomeShiny(): void
     {
         $this->apiRequest('GET', '/album/7b52009b64fd0a2a49e6d8a939753077792b0554/home_shiny');
 
@@ -490,7 +497,8 @@ final class AlbumIndexControllerTest extends AbstractTestControllerApi
         $this->assertReport($report, 11, 0, 0, 0, 11);
     }
 
-    public function testListHomePoGo(): void
+    #[Test]
+    public function listHomePoGo(): void
     {
         $this->apiRequest('GET', '/album/7b52009b64fd0a2a49e6d8a939753077792b0554/home_pogo');
 
@@ -535,7 +543,8 @@ final class AlbumIndexControllerTest extends AbstractTestControllerApi
         $this->assertPokemonsHaveGameBundlesStructure($pokemons);
     }
 
-    public function testListHomeShinyOT(): void
+    #[Test]
+    public function listHomeShinyOT(): void
     {
         $this->apiRequest('GET', '/album/7b52009b64fd0a2a49e6d8a939753077792b0554/homeshinyot');
 
@@ -580,7 +589,8 @@ final class AlbumIndexControllerTest extends AbstractTestControllerApi
         $this->assertPokemonsHaveGameBundlesStructure($pokemons);
     }
 
-    public function testListMultipleHomePoGo(): void
+    #[Test]
+    public function listMultipleHomePoGo(): void
     {
         $this->apiRequest('GET', '/album/7b52009b64fd0a2a49e6d8a939753077792b0554/homepogo');
 
@@ -613,7 +623,8 @@ final class AlbumIndexControllerTest extends AbstractTestControllerApi
         $this->assertReport($report, 0, 0, 0, 0, 0);
     }
 
-    public function testListNoSlug(): void
+    #[Test]
+    public function listNoSlug(): void
     {
         $this->apiRequest('GET', 'album', []);
 
@@ -628,7 +639,8 @@ final class AlbumIndexControllerTest extends AbstractTestControllerApi
         $this->assertResponseIsNotFound();
     }
 
-    public function testListNoUser(): void
+    #[Test]
+    public function listNoUser(): void
     {
         $this->apiRequest('GET', '/album/home', []);
 

--- a/tests/src/Integration/Controller/AlbumIndexFilteredController/CatchStatesTest.php
+++ b/tests/src/Integration/Controller/AlbumIndexFilteredController/CatchStatesTest.php
@@ -8,6 +8,7 @@ use App\Controller\AlbumIndexController;
 use App\Tests\Common\Traits\PokemonListTrait;
 use App\Tests\Common\Traits\ReportTrait\AssertReportTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -20,7 +21,8 @@ final class CatchStatesTest extends AbstractTestAlbumIndexFilteredController
     use AssertReportTrait;
     use PokemonListTrait;
 
-    public function testCatchStateFilter(): void
+    #[Test]
+    public function catchStateFilter(): void
     {
         $this->apiRequest(
             'GET',
@@ -64,7 +66,8 @@ final class CatchStatesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testCatchStateFilterNegative(): void
+    #[Test]
+    public function catchStateFilterNegative(): void
     {
         $this->apiRequest(
             'GET',
@@ -101,7 +104,8 @@ final class CatchStatesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testNoCatchStateFilter(): void
+    #[Test]
+    public function noCatchStateFilter(): void
     {
         $this->apiRequest(
             'GET',
@@ -138,7 +142,8 @@ final class CatchStatesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testCatchStateFilterNegativeNo(): void
+    #[Test]
+    public function catchStateFilterNegativeNo(): void
     {
         $this->apiRequest(
             'GET',
@@ -175,7 +180,8 @@ final class CatchStatesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testCatchStateFilterNull(): void
+    #[Test]
+    public function catchStateFilterNull(): void
     {
         $this->apiRequest(
             'GET',
@@ -200,7 +206,8 @@ final class CatchStatesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertCount(1, $pokemons);
     }
 
-    public function testCatchStatesFilter(): void
+    #[Test]
+    public function catchStatesFilter(): void
     {
         $this->apiRequest(
             'GET',

--- a/tests/src/Integration/Controller/AlbumIndexFilteredController/CollectionsAvailabilitiesTest.php
+++ b/tests/src/Integration/Controller/AlbumIndexFilteredController/CollectionsAvailabilitiesTest.php
@@ -8,6 +8,7 @@ use App\Controller\AlbumIndexController;
 use App\Tests\Common\Traits\PokemonListTrait;
 use App\Tests\Common\Traits\ReportTrait\AssertReportTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -20,7 +21,8 @@ final class CollectionsAvailabilitiesTest extends AbstractTestAlbumIndexFiltered
     use AssertReportTrait;
     use PokemonListTrait;
 
-    public function testCollectionsAvailabilitiesFilter(): void
+    #[Test]
+    public function collectionsAvailabilitiesFilter(): void
     {
         $this->apiRequest(
             'GET',
@@ -62,7 +64,8 @@ final class CollectionsAvailabilitiesTest extends AbstractTestAlbumIndexFiltered
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testCollectionAvailabililiesNullFilter(): void
+    #[Test]
+    public function collectionAvailabililiesNullFilter(): void
     {
         $this->apiRequest(
             'GET',
@@ -86,7 +89,8 @@ final class CollectionsAvailabilitiesTest extends AbstractTestAlbumIndexFiltered
         $this->assertCount(0, $pokemons);
     }
 
-    public function testCollectionsAvailabilitiesNegativeFilter(): void
+    #[Test]
+    public function collectionsAvailabilitiesNegativeFilter(): void
     {
         $this->apiRequest(
             'GET',

--- a/tests/src/Integration/Controller/AlbumIndexFilteredController/CommonTest.php
+++ b/tests/src/Integration/Controller/AlbumIndexFilteredController/CommonTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Controller\AlbumIndexFilteredController;
 use App\Controller\AlbumIndexController;
 use App\Tests\Common\Traits\ReportTrait\AssertReportTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -18,7 +19,8 @@ final class CommonTest extends AbstractTestAlbumIndexFilteredController
 {
     use AssertReportTrait;
 
-    public function testEmptyFilters(): void
+    #[Test]
+    public function emptyFilters(): void
     {
         $this->apiRequest(
             'GET',

--- a/tests/src/Integration/Controller/AlbumIndexFilteredController/FamiliesTest.php
+++ b/tests/src/Integration/Controller/AlbumIndexFilteredController/FamiliesTest.php
@@ -8,6 +8,7 @@ use App\Controller\AlbumIndexController;
 use App\Tests\Common\Traits\PokemonListTrait;
 use App\Tests\Common\Traits\ReportTrait\AssertReportTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -20,7 +21,8 @@ final class FamiliesTest extends AbstractTestAlbumIndexFilteredController
     use AssertReportTrait;
     use PokemonListTrait;
 
-    public function testFamilyFilter(): void
+    #[Test]
+    public function familyFilter(): void
     {
         $this->apiRequest(
             'GET',
@@ -67,7 +69,8 @@ final class FamiliesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testFamilyFilterNull(): void
+    #[Test]
+    public function familyFilterNull(): void
     {
         $this->apiRequest(
             'GET',
@@ -92,7 +95,8 @@ final class FamiliesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertCount(0, $pokemons);
     }
 
-    public function testFamiliesFilter(): void
+    #[Test]
+    public function familiesFilter(): void
     {
         $this->apiRequest(
             'GET',

--- a/tests/src/Integration/Controller/AlbumIndexFilteredController/FormsTest.php
+++ b/tests/src/Integration/Controller/AlbumIndexFilteredController/FormsTest.php
@@ -8,6 +8,7 @@ use App\Controller\AlbumIndexController;
 use App\Tests\Common\Traits\PokemonListTrait;
 use App\Tests\Common\Traits\ReportTrait\AssertReportTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -20,7 +21,8 @@ final class FormsTest extends AbstractTestAlbumIndexFilteredController
     use AssertReportTrait;
     use PokemonListTrait;
 
-    public function testCategoryForm(): void
+    #[Test]
+    public function categoryForm(): void
     {
         $this->apiRequest(
             'GET',
@@ -63,7 +65,8 @@ final class FormsTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testCategoryFormNull(): void
+    #[Test]
+    public function categoryFormNull(): void
     {
         $this->apiRequest(
             'GET',
@@ -88,7 +91,8 @@ final class FormsTest extends AbstractTestAlbumIndexFilteredController
         $this->assertCount(20, $pokemons);
     }
 
-    public function testRegionalForm(): void
+    #[Test]
+    public function regionalForm(): void
     {
         $this->apiRequest(
             'GET',
@@ -132,7 +136,8 @@ final class FormsTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testRegionalFormNull(): void
+    #[Test]
+    public function regionalFormNull(): void
     {
         $this->apiRequest(
             'GET',
@@ -157,7 +162,8 @@ final class FormsTest extends AbstractTestAlbumIndexFilteredController
         $this->assertCount(19, $pokemons);
     }
 
-    public function testSpecialForm(): void
+    #[Test]
+    public function specialForm(): void
     {
         $this->apiRequest(
             'GET',
@@ -200,7 +206,8 @@ final class FormsTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testSpecialFormNull(): void
+    #[Test]
+    public function specialFormNull(): void
     {
         $this->apiRequest(
             'GET',
@@ -225,7 +232,8 @@ final class FormsTest extends AbstractTestAlbumIndexFilteredController
         $this->assertCount(18, $pokemons);
     }
 
-    public function testSpecialsForm(): void
+    #[Test]
+    public function specialsForm(): void
     {
         $this->apiRequest(
             'GET',
@@ -270,7 +278,8 @@ final class FormsTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testVariantForm(): void
+    #[Test]
+    public function variantForm(): void
     {
         $this->apiRequest(
             'GET',
@@ -315,7 +324,8 @@ final class FormsTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testVariantFormNull(): void
+    #[Test]
+    public function variantFormNull(): void
     {
         $this->apiRequest(
             'GET',

--- a/tests/src/Integration/Controller/AlbumIndexFilteredController/GamesTest.php
+++ b/tests/src/Integration/Controller/AlbumIndexFilteredController/GamesTest.php
@@ -8,6 +8,7 @@ use App\Controller\AlbumIndexController;
 use App\Tests\Common\Traits\PokemonListTrait;
 use App\Tests\Common\Traits\ReportTrait\AssertReportTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -20,7 +21,8 @@ final class GamesTest extends AbstractTestAlbumIndexFilteredController
     use AssertReportTrait;
     use PokemonListTrait;
 
-    public function testOriginalGameBundle(): void
+    #[Test]
+    public function originalGameBundle(): void
     {
         $this->apiRequest(
             'GET',
@@ -73,7 +75,8 @@ final class GamesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testOriginalGameBundleNull(): void
+    #[Test]
+    public function originalGameBundleNull(): void
     {
         $this->apiRequest(
             'GET',
@@ -98,7 +101,8 @@ final class GamesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertCount(0, $pokemons);
     }
 
-    public function testGameBundleAvailabilities(): void
+    #[Test]
+    public function gameBundleAvailabilities(): void
     {
         $this->apiRequest(
             'GET',
@@ -141,7 +145,8 @@ final class GamesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testGameBundleAvailabilitiesNull(): void
+    #[Test]
+    public function gameBundleAvailabilitiesNull(): void
     {
         $this->apiRequest(
             'GET',
@@ -166,7 +171,8 @@ final class GamesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertCount(0, $pokemons);
     }
 
-    public function testGameBundleAvailabilitiesNegative(): void
+    #[Test]
+    public function gameBundleAvailabilitiesNegative(): void
     {
         $this->apiRequest(
             'GET',
@@ -227,7 +233,8 @@ final class GamesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testGameBundleShinyAvailabilities(): void
+    #[Test]
+    public function gameBundleShinyAvailabilities(): void
     {
         $this->apiRequest(
             'GET',
@@ -272,7 +279,8 @@ final class GamesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testGameBundleShinyAvailabilitiesNull(): void
+    #[Test]
+    public function gameBundleShinyAvailabilitiesNull(): void
     {
         $this->apiRequest(
             'GET',
@@ -297,7 +305,8 @@ final class GamesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertCount(0, $pokemons);
     }
 
-    public function testGameBundleShinyAvailabilitiesNegative(): void
+    #[Test]
+    public function gameBundleShinyAvailabilitiesNegative(): void
     {
         $this->apiRequest(
             'GET',

--- a/tests/src/Integration/Controller/AlbumIndexFilteredController/ImageCreditTest.php
+++ b/tests/src/Integration/Controller/AlbumIndexFilteredController/ImageCreditTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Controller\AlbumIndexFilteredController;
 
 use App\Controller\AlbumIndexController;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -13,7 +14,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(AlbumIndexController::class)]
 final class ImageCreditTest extends AbstractTestAlbumIndexFilteredController
 {
-    public function testIndexIncludesBulbasaurImageCredits(): void
+    #[Test]
+    public function indexIncludesBulbasaurImageCredits(): void
     {
         $this->apiRequest(
             'GET',

--- a/tests/src/Integration/Controller/AlbumIndexFilteredController/TypesTest.php
+++ b/tests/src/Integration/Controller/AlbumIndexFilteredController/TypesTest.php
@@ -8,6 +8,7 @@ use App\Controller\AlbumIndexController;
 use App\Tests\Common\Traits\PokemonListTrait;
 use App\Tests\Common\Traits\ReportTrait\AssertReportTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -20,7 +21,8 @@ final class TypesTest extends AbstractTestAlbumIndexFilteredController
     use AssertReportTrait;
     use PokemonListTrait;
 
-    public function testPrimaryTypeFilter(): void
+    #[Test]
+    public function primaryTypeFilter(): void
     {
         $this->apiRequest(
             'GET',
@@ -67,7 +69,8 @@ final class TypesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testPrimaryTypeNullFilter(): void
+    #[Test]
+    public function primaryTypeNullFilter(): void
     {
         $this->apiRequest(
             'GET',
@@ -91,7 +94,8 @@ final class TypesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertCount(1, $pokemons);
     }
 
-    public function testSecondaryTypeFilter(): void
+    #[Test]
+    public function secondaryTypeFilter(): void
     {
         $this->apiRequest(
             'GET',
@@ -135,7 +139,8 @@ final class TypesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testSecondaryTypeNullFilter(): void
+    #[Test]
+    public function secondaryTypeNullFilter(): void
     {
         $this->apiRequest(
             'GET',
@@ -160,7 +165,8 @@ final class TypesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertCount(9, $pokemons);
     }
 
-    public function testPrimaryAndSecondaryTypeFilter(): void
+    #[Test]
+    public function primaryAndSecondaryTypeFilter(): void
     {
         $this->apiRequest(
             'GET',
@@ -207,7 +213,8 @@ final class TypesTest extends AbstractTestAlbumIndexFilteredController
         $this->assertReport($report, 9, 3, 3, 7, 22);
     }
 
-    public function testAnyTypeFilter(): void
+    #[Test]
+    public function anyTypeFilter(): void
     {
         $this->apiRequest(
             'GET',

--- a/tests/src/Integration/Controller/AlbumUpsertControllerTest.php
+++ b/tests/src/Integration/Controller/AlbumUpsertControllerTest.php
@@ -10,6 +10,7 @@ use App\Tests\Common\Traits\CounterTrait\CountTrainerDexTrait;
 use App\Tests\Common\Traits\GetterTrait\GetPokedexTrait;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -36,7 +37,8 @@ final class AlbumUpsertControllerTest extends AbstractTestControllerApi
         $this->client->disableReboot();
     }
 
-    public function testUpdate(): void
+    #[Test]
+    public function update(): void
     {
         $pokedexBefore = $this->getPokedexFromSlugs('redgreenblueyellow', 'ivysaur');
 
@@ -62,7 +64,8 @@ final class AlbumUpsertControllerTest extends AbstractTestControllerApi
         $this->assertEquals(34, $this->getTrainerDexCount());
     }
 
-    public function testUpdateEmpty(): void
+    #[Test]
+    public function updateEmpty(): void
     {
         $this->apiRequest(
             'PATCH',
@@ -75,7 +78,8 @@ final class AlbumUpsertControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testUpdateNonExistingDex(): void
+    #[Test]
+    public function updateNonExistingDex(): void
     {
         $pokedexBefore = $this->getPokedexFromSlugs('douze', 'ivysaur');
 
@@ -100,7 +104,8 @@ final class AlbumUpsertControllerTest extends AbstractTestControllerApi
         $this->assertEmpty($pokedexAfter);
     }
 
-    public function testUpdateNonExistingPokemon(): void
+    #[Test]
+    public function updateNonExistingPokemon(): void
     {
         $this->apiRequest(
             'PATCH',
@@ -113,7 +118,8 @@ final class AlbumUpsertControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testCreate(): void
+    #[Test]
+    public function create(): void
     {
         $pokedexBefore = $this->getPokedexFromSlugs('goldsilvercrystal', 'douze');
 
@@ -144,7 +150,8 @@ final class AlbumUpsertControllerTest extends AbstractTestControllerApi
         $this->assertEquals(34, $this->getTrainerDexCount());
     }
 
-    public function testCreateNonExistingTrainerDex(): void
+    #[Test]
+    public function createNonExistingTrainerDex(): void
     {
         $pokedexBefore = $this->getPokedexFromSlugs('spoon', 'douze');
 
@@ -174,7 +181,8 @@ final class AlbumUpsertControllerTest extends AbstractTestControllerApi
         $this->assertEquals(35, $this->getTrainerDexCount());
     }
 
-    public function testCreateNonExistingDex(): void
+    #[Test]
+    public function createNonExistingDex(): void
     {
         $pokedexBefore = $this->getPokedexFromSlugs('douze', 'ivysaur');
 
@@ -199,7 +207,8 @@ final class AlbumUpsertControllerTest extends AbstractTestControllerApi
         $this->assertEmpty($pokedexAfter);
     }
 
-    public function testCreateNonExistingPokemon(): void
+    #[Test]
+    public function createNonExistingPokemon(): void
     {
         $this->apiRequest(
             'PUT',
@@ -212,7 +221,8 @@ final class AlbumUpsertControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testCreateEmpty(): void
+    #[Test]
+    public function createEmpty(): void
     {
         $this->apiRequest(
             'PUT',
@@ -225,7 +235,8 @@ final class AlbumUpsertControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testUpdateCascadesThroughAnActiveLink(): void
+    #[Test]
+    public function updateCascadesThroughAnActiveLink(): void
     {
         $this->apiRequest(
             'POST',

--- a/tests/src/Integration/Controller/Debug/DebugPokemonControllerTest.php
+++ b/tests/src/Integration/Controller/Debug/DebugPokemonControllerTest.php
@@ -9,6 +9,7 @@ use App\Factory\PokemonDebugResponseFactory;
 use App\Service\DexAvailabilitiesService;
 use App\Tests\Integration\Controller\AbstractTestControllerApi;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -18,7 +19,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(PokemonDebugResponseFactory::class)]
 final class DebugPokemonControllerTest extends AbstractTestControllerApi
 {
-    public function testPokemon(): void
+    #[Test]
+    public function pokemon(): void
     {
         $this->apiRequest('GET', '/debogage/pokemon/venusaur-mega');
 
@@ -45,14 +47,16 @@ final class DebugPokemonControllerTest extends AbstractTestControllerApi
         $this->assertStringContainsString('"slug":"poison",', $content);
     }
 
-    public function testPokemonNotFound(): void
+    #[Test]
+    public function pokemonNotFound(): void
     {
         $this->apiRequest('GET', '/debogage/pokemon/venusaur-mega-x');
 
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testPokemonCleanCaches(): void
+    #[Test]
+    public function pokemonCleanCaches(): void
     {
         $this->apiRequest('DELETE', '/debogage/pokemon/venusaur-mega/caches');
 
@@ -61,14 +65,16 @@ final class DebugPokemonControllerTest extends AbstractTestControllerApi
         $this->assertEmpty($this->getClientResponseContent());
     }
 
-    public function testPokemonCleanCachesNotFound(): void
+    #[Test]
+    public function pokemonCleanCachesNotFound(): void
     {
         $this->apiRequest('DELETE', '/debogage/pokemon/venusaur-mega-x/caches');
 
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testPokemonAvailabilities(): void
+    #[Test]
+    public function pokemonAvailabilities(): void
     {
         $this->apiRequest('GET', '/debogage/pokemon/venusaur-mega/availabilities');
 
@@ -128,7 +134,8 @@ final class DebugPokemonControllerTest extends AbstractTestControllerApi
         }
     }
 
-    public function testPokemonAvailabilitiesNotFound(): void
+    #[Test]
+    public function pokemonAvailabilitiesNotFound(): void
     {
         $this->apiRequest('GET', '/debogage/pokemon/venusaur-mega-x/availabilities');
 

--- a/tests/src/Integration/Controller/DexControllerTest.php
+++ b/tests/src/Integration/Controller/DexControllerTest.php
@@ -10,6 +10,7 @@ use App\DTO\Response\TrainerDexSettingsResponse;
 use App\Factory\TrainerDexResponseFactory;
 use App\Tests\Common\Traits\GetterTrait\GetTrainerDexTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -25,7 +26,8 @@ final class DexControllerTest extends AbstractTestControllerApi
     /** @var array<string, array<string, mixed>> */
     private array $lastResponseReportsBySlug = [];
 
-    public function testListUser12(): void
+    #[Test]
+    public function listUser12(): void
     {
         $this->apiRequest('GET', '/dex/7b52009b64fd0a2a49e6d8a939753077792b0554/list');
 
@@ -41,7 +43,8 @@ final class DexControllerTest extends AbstractTestControllerApi
         $this->assertKnownReport('home_shiny', 11, 0, 0, 0, 11);
     }
 
-    public function testListUser12WithUnReleased(): void
+    #[Test]
+    public function listUser12WithUnReleased(): void
     {
         $this->apiRequest(
             'GET',
@@ -63,7 +66,8 @@ final class DexControllerTest extends AbstractTestControllerApi
         $this->assertKnownReport('goldsilvercrystal', 8, 0, 0, 1, 9);
     }
 
-    public function testListUser12WithPremium(): void
+    #[Test]
+    public function listUser12WithPremium(): void
     {
         $this->apiRequest(
             'GET',
@@ -84,7 +88,8 @@ final class DexControllerTest extends AbstractTestControllerApi
         $this->assertKnownReport('home', 9, 3, 3, 7, 22);
     }
 
-    public function testListUser12WithUnreleasedAndPremium(): void
+    #[Test]
+    public function listUser12WithUnreleasedAndPremium(): void
     {
         $this->apiRequest(
             'GET',
@@ -107,7 +112,8 @@ final class DexControllerTest extends AbstractTestControllerApi
         $this->assertKnownReport('goldsilvercrystal', 8, 0, 0, 1, 9);
     }
 
-    public function testListUser13(): void
+    #[Test]
+    public function listUser13(): void
     {
         $this->apiRequest('GET', '/dex/bd307a3ec329e10a2cff8fb87480823da114f8f4/list');
 
@@ -122,7 +128,8 @@ final class DexControllerTest extends AbstractTestControllerApi
         $this->assertReportShapeIsWellFormed();
     }
 
-    public function testListUserUnknown(): void
+    #[Test]
+    public function listUserUnknown(): void
     {
         $this->apiRequest('GET', '/dex/46546542313186/list');
 
@@ -137,7 +144,8 @@ final class DexControllerTest extends AbstractTestControllerApi
         $this->assertReportShapeIsWellFormed();
     }
 
-    public function testUpdate(): void
+    #[Test]
+    public function update(): void
     {
         $trainerDexBefore = $this->getTrainerDex('7b52009b64fd0a2a49e6d8a939753077792b0554', 'redgreenblueyellow');
 
@@ -170,7 +178,8 @@ final class DexControllerTest extends AbstractTestControllerApi
         $this->assertEquals('redgreenblueyellow', $trainerDexAfter['slug']);
     }
 
-    public function testUpdateTrainerSlug(): void
+    #[Test]
+    public function updateTrainerSlug(): void
     {
         $trainerDexBefore = $this->getTrainerDex('7b52009b64fd0a2a49e6d8a939753077792b0554', 'homepogopokeball');
 
@@ -203,7 +212,8 @@ final class DexControllerTest extends AbstractTestControllerApi
         $this->assertEquals('homepogopokeball', $trainerDexAfter['slug']);
     }
 
-    public function testCreate(): void
+    #[Test]
+    public function create(): void
     {
         $trainerDexBefore = $this->getTrainerDex('fa35e192121eabf3dabf9f5ea6abdbcbc107ac3b', 'redgreenblueyellow');
 
@@ -230,7 +240,8 @@ final class DexControllerTest extends AbstractTestControllerApi
         $this->assertEquals('redgreenblueyellow', $trainerDexAfter['slug']);
     }
 
-    public function testCreateWithMissingAttribute(): void
+    #[Test]
+    public function createWithMissingAttribute(): void
     {
         $trainerDexBefore = $this->getTrainerDex('fa35e192121eabf3dabf9f5ea6abdbcbc107ac3b', 'redgreenblueyellow');
 
@@ -257,7 +268,8 @@ final class DexControllerTest extends AbstractTestControllerApi
         $this->assertEquals('redgreenblueyellow', $trainerDexAfter['slug']);
     }
 
-    public function testBadArgument(): void
+    #[Test]
+    public function badArgument(): void
     {
         $this->apiRequest(
             'PUT',
@@ -270,7 +282,8 @@ final class DexControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testEmptyData(): void
+    #[Test]
+    public function emptyData(): void
     {
         $this->apiRequest(
             'PUT',

--- a/tests/src/Integration/Controller/ElectionReportControllerTest.php
+++ b/tests/src/Integration/Controller/ElectionReportControllerTest.php
@@ -14,6 +14,7 @@ use App\Factory\ElectionEloResponseFactory;
 use App\Factory\ElectionMetricsResponseFactory;
 use App\Factory\ElectionReportResponseFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -31,7 +32,8 @@ final class ElectionReportControllerTest extends AbstractTestControllerApi
 {
     private const string TRAINER_U12 = '7b52009b64fd0a2a49e6d8a939753077792b0554';
 
-    public function testShowReturnsTopAndMetricsForHomeFavorite(): void
+    #[Test]
+    public function showReturnsTopAndMetricsForHomeFavorite(): void
     {
         $this->apiRequest(
             'GET',
@@ -59,7 +61,8 @@ final class ElectionReportControllerTest extends AbstractTestControllerApi
         }
     }
 
-    public function testShowReturnsMetricsForDemoWithDefaultElectionSlug(): void
+    #[Test]
+    public function showReturnsMetricsForDemoWithDefaultElectionSlug(): void
     {
         $this->apiRequest(
             'GET',
@@ -87,7 +90,8 @@ final class ElectionReportControllerTest extends AbstractTestControllerApi
         );
     }
 
-    public function testShowReturnsMetricsForAffineeElection(): void
+    #[Test]
+    public function showReturnsMetricsForAffineeElection(): void
     {
         $this->apiRequest(
             'GET',
@@ -114,7 +118,8 @@ final class ElectionReportControllerTest extends AbstractTestControllerApi
         );
     }
 
-    public function testShowDefaultsElectionSlugAndCountWhenOmitted(): void
+    #[Test]
+    public function showDefaultsElectionSlugAndCountWhenOmitted(): void
     {
         $this->apiRequest('GET', '/election/'.self::TRAINER_U12.'/demo');
 
@@ -126,7 +131,8 @@ final class ElectionReportControllerTest extends AbstractTestControllerApi
         $this->assertCount(5, $content['top']);
     }
 
-    public function testShowWithAuth(): void
+    #[Test]
+    public function showWithAuth(): void
     {
         $this->apiRequest(
             'GET',
@@ -138,7 +144,8 @@ final class ElectionReportControllerTest extends AbstractTestControllerApi
         $this->assertResponseIsOK();
     }
 
-    public function testShowWithBadAuth(): void
+    #[Test]
+    public function showWithBadAuth(): void
     {
         $this->apiRequest(
             'GET',
@@ -150,7 +157,8 @@ final class ElectionReportControllerTest extends AbstractTestControllerApi
         $this->assertEquals(401, $this->getClientResponse()->getStatusCode());
     }
 
-    public function testListReturnsOneDexByDefault(): void
+    #[Test]
+    public function listReturnsOneDexByDefault(): void
     {
         $this->apiRequest('GET', '/election/'.self::TRAINER_U12.'/list');
 
@@ -166,7 +174,8 @@ final class ElectionReportControllerTest extends AbstractTestControllerApi
         $this->assertArrayHasKey('metrics', $content[0]['report']);
     }
 
-    public function testListReturnsAllEligibleDexWithOptions(): void
+    #[Test]
+    public function listReturnsAllEligibleDexWithOptions(): void
     {
         // 'favorite' is the election_slug used across fixtures for 'home' and
         // 'redgreenblueyellow' (see fixtures/trainer_pokemon_elo.yaml); it's passed
@@ -202,7 +211,8 @@ final class ElectionReportControllerTest extends AbstractTestControllerApi
         $this->assertCount(1, $bySlug['redgreenblueyellow']['report']['top']);
     }
 
-    public function testListIsNotShadowedByTheSingleDexRoute(): void
+    #[Test]
+    public function listIsNotShadowedByTheSingleDexRoute(): void
     {
         $this->apiRequest('GET', '/election/'.self::TRAINER_U12.'/list');
 

--- a/tests/src/Integration/Controller/ElectionVoteControllerTest.php
+++ b/tests/src/Integration/Controller/ElectionVoteControllerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Controller;
 use App\Controller\ElectionVoteController;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
@@ -17,7 +18,8 @@ final class ElectionVoteControllerTest extends WebTestCase
 {
     use RefreshDatabaseTrait;
 
-    public function testVote(): void
+    #[Test]
+    public function vote(): void
     {
         $client = self::createClient();
 
@@ -76,7 +78,8 @@ final class ElectionVoteControllerTest extends WebTestCase
         );
     }
 
-    public function testVoteBis(): void
+    #[Test]
+    public function voteBis(): void
     {
         $client = self::createClient();
 
@@ -135,7 +138,8 @@ final class ElectionVoteControllerTest extends WebTestCase
         );
     }
 
-    public function testVoteAllLosers(): void
+    #[Test]
+    public function voteAllLosers(): void
     {
         $client = self::createClient();
 
@@ -192,7 +196,8 @@ final class ElectionVoteControllerTest extends WebTestCase
         );
     }
 
-    public function testVoteAllWinners(): void
+    #[Test]
+    public function voteAllWinners(): void
     {
         $client = self::createClient();
 
@@ -249,7 +254,8 @@ final class ElectionVoteControllerTest extends WebTestCase
         );
     }
 
-    public function testEmptyData(): void
+    #[Test]
+    public function emptyData(): void
     {
         $client = self::createClient();
 
@@ -268,7 +274,8 @@ final class ElectionVoteControllerTest extends WebTestCase
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testEmptyDataBis(): void
+    #[Test]
+    public function emptyDataBis(): void
     {
         $client = self::createClient();
 
@@ -287,7 +294,8 @@ final class ElectionVoteControllerTest extends WebTestCase
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testBadVote(): void
+    #[Test]
+    public function badVote(): void
     {
         $client = self::createClient();
 

--- a/tests/src/Integration/Controller/GameBundlesControllerTest.php
+++ b/tests/src/Integration/Controller/GameBundlesControllerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Controller;
 use App\Controller\GameBundlesController;
 use App\Service\GameBundlesService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -15,7 +16,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(GameBundlesService::class)]
 final class GameBundlesControllerTest extends AbstractTestControllerApi
 {
-    public function testGetCollection(): void
+    #[Test]
+    public function getCollection(): void
     {
         $this->apiRequest('GET', '/game_bundles');
 
@@ -48,7 +50,8 @@ final class GameBundlesControllerTest extends AbstractTestControllerApi
         ], $content[6]);
     }
 
-    public function testGetAuth(): void
+    #[Test]
+    public function getAuth(): void
     {
         $this->apiRequest('GET', '/game_bundles', [], ['PHP_AUTH_USER' => self::AUTH_USER, 'PHP_AUTH_PW' => self::AUTH_PASSWORD]);
 
@@ -60,7 +63,8 @@ final class GameBundlesControllerTest extends AbstractTestControllerApi
         $this->assertCount(19, $content);
     }
 
-    public function testGetBadAuth(): void
+    #[Test]
+    public function getBadAuth(): void
     {
         $this->apiRequest('GET', '/game_bundles', [], ['PHP_AUTH_USER' => self::AUTH_USER, 'PHP_AUTH_PW' => 'treize']);
 

--- a/tests/src/Integration/Controller/ImagePipelineRunControllerTest.php
+++ b/tests/src/Integration/Controller/ImagePipelineRunControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Controller;
 
 use App\Controller\ImagePipelineRunController;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -26,7 +27,8 @@ final class ImagePipelineRunControllerTest extends AbstractTestControllerApi
         $this->client->disableReboot();
     }
 
-    public function testCreateThenGetLatest(): void
+    #[Test]
+    public function createThenGetLatest(): void
     {
         $this->apiRequest(
             'POST',
@@ -49,7 +51,8 @@ final class ImagePipelineRunControllerTest extends AbstractTestControllerApi
         $this->assertNull($data['workflow_a_run_id']);
     }
 
-    public function testCreateWithDuplicateCorrelationIdConflicts(): void
+    #[Test]
+    public function createWithDuplicateCorrelationIdConflicts(): void
     {
         $this->apiRequest(
             'POST',
@@ -70,7 +73,8 @@ final class ImagePipelineRunControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(409);
     }
 
-    public function testCreateWithMissingCorrelationIdIsBadRequest(): void
+    #[Test]
+    public function createWithMissingCorrelationIdIsBadRequest(): void
     {
         $this->apiRequest(
             'POST',
@@ -83,7 +87,8 @@ final class ImagePipelineRunControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testCreateWithNonStringCorrelationIdIsBadRequest(): void
+    #[Test]
+    public function createWithNonStringCorrelationIdIsBadRequest(): void
     {
         $this->apiRequest(
             'POST',
@@ -96,7 +101,8 @@ final class ImagePipelineRunControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testCreateWithEmptyBodyIsBadRequest(): void
+    #[Test]
+    public function createWithEmptyBodyIsBadRequest(): void
     {
         $this->apiRequest(
             'POST',
@@ -109,14 +115,16 @@ final class ImagePipelineRunControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testGetLatestReturns404WhenNoneExist(): void
+    #[Test]
+    public function getLatestReturns404WhenNoneExist(): void
     {
         $this->apiRequest('GET', '/istration/image-pipeline-runs/latest');
 
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testPatchAppliesFields(): void
+    #[Test]
+    public function patchAppliesFields(): void
     {
         $this->apiRequest(
             'POST',
@@ -145,7 +153,8 @@ final class ImagePipelineRunControllerTest extends AbstractTestControllerApi
         $this->assertSame('completed', $data['workflow_a_status']);
     }
 
-    public function testPatchReturns404WhenCorrelationIdUnknown(): void
+    #[Test]
+    public function patchReturns404WhenCorrelationIdUnknown(): void
     {
         $this->apiRequest(
             'PATCH',
@@ -157,7 +166,8 @@ final class ImagePipelineRunControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testPatchWithEmptyBodyIsBadRequest(): void
+    #[Test]
+    public function patchWithEmptyBodyIsBadRequest(): void
     {
         $this->apiRequest(
             'POST',

--- a/tests/src/Integration/Controller/PokemonsControllerTest.php
+++ b/tests/src/Integration/Controller/PokemonsControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Controller;
 
 use App\Controller\PokemonsController;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -13,7 +14,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(PokemonsController::class)]
 final class PokemonsControllerTest extends AbstractTestControllerApi
 {
-    public function testGetListFromDex(): void
+    #[Test]
+    public function getListFromDex(): void
     {
         $this->apiRequest(
             'GET',
@@ -30,7 +32,8 @@ final class PokemonsControllerTest extends AbstractTestControllerApi
         $this->assertResponseContent(12);
     }
 
-    public function testGetListFromDexBis(): void
+    #[Test]
+    public function getListFromDexBis(): void
     {
         $this->apiRequest(
             'GET',
@@ -47,7 +50,8 @@ final class PokemonsControllerTest extends AbstractTestControllerApi
         $this->assertResponseContent(7);
     }
 
-    public function testGetListFromDexTer(): void
+    #[Test]
+    public function getListFromDexTer(): void
     {
         $this->apiRequest(
             'GET',
@@ -65,7 +69,8 @@ final class PokemonsControllerTest extends AbstractTestControllerApi
         $this->assertResponseContent(1);
     }
 
-    public function testGetAuth(): void
+    #[Test]
+    public function getAuth(): void
     {
         $this->apiRequest(
             'GET',
@@ -86,7 +91,8 @@ final class PokemonsControllerTest extends AbstractTestControllerApi
         $this->assertResponseContent(12);
     }
 
-    public function testGetBadAuth(): void
+    #[Test]
+    public function getBadAuth(): void
     {
         $this->apiRequest(
             'GET',

--- a/tests/src/Integration/Controller/TrainerDexLinkControllerTest.php
+++ b/tests/src/Integration/Controller/TrainerDexLinkControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Controller;
 
 use App\Controller\TrainerDexLinkController;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -31,7 +32,8 @@ final class TrainerDexLinkControllerTest extends AbstractTestControllerApi
         $this->client->disableReboot();
     }
 
-    public function testCreateListAndDelete(): void
+    #[Test]
+    public function createListAndDelete(): void
     {
         $this->apiRequest('GET', '/trainer_dex_link/'.self::TRAINER.'/redgreenblueyellow');
         $this->assertResponseIsOK();
@@ -65,7 +67,8 @@ final class TrainerDexLinkControllerTest extends AbstractTestControllerApi
         $this->assertSame([], $this->getJsonDecodedResponseContent());
     }
 
-    public function testCreateRejectsSelfLink(): void
+    #[Test]
+    public function createRejectsSelfLink(): void
     {
         $this->apiRequest(
             'POST',
@@ -81,7 +84,8 @@ final class TrainerDexLinkControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testCreateRejectsUnknownDex(): void
+    #[Test]
+    public function createRejectsUnknownDex(): void
     {
         $this->apiRequest(
             'POST',
@@ -97,7 +101,8 @@ final class TrainerDexLinkControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testCreateRejectsDuplicateEdge(): void
+    #[Test]
+    public function createRejectsDuplicateEdge(): void
     {
         $body = json_encode(
             ['sourceDexSlug' => 'redgreenblueyellow', 'targetDexSlug' => 'goldsilvercrystal', 'bidirectional' => false],
@@ -111,21 +116,24 @@ final class TrainerDexLinkControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(409);
     }
 
-    public function testCreateEmptyBody(): void
+    #[Test]
+    public function createEmptyBody(): void
     {
         $this->apiRequest('POST', '/trainer_dex_link/'.self::TRAINER, [], null, '');
 
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testCreateMissingFields(): void
+    #[Test]
+    public function createMissingFields(): void
     {
         $this->apiRequest('POST', '/trainer_dex_link/'.self::TRAINER, [], null, json_encode(['sourceDexSlug' => 'redgreenblueyellow'], JSON_THROW_ON_ERROR));
 
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testCreateRejectsNonBooleanBidirectional(): void
+    #[Test]
+    public function createRejectsNonBooleanBidirectional(): void
     {
         $this->apiRequest(
             'POST',
@@ -141,7 +149,8 @@ final class TrainerDexLinkControllerTest extends AbstractTestControllerApi
         $this->assertResponseStatusCodeSame(400);
     }
 
-    public function testCreateBidirectional(): void
+    #[Test]
+    public function createBidirectional(): void
     {
         $this->apiRequest(
             'POST',

--- a/tests/src/Integration/MessageHandler/CalculateDexAvailabilitiesHandlerTest.php
+++ b/tests/src/Integration/MessageHandler/CalculateDexAvailabilitiesHandlerTest.php
@@ -13,6 +13,7 @@ use App\Tests\Common\Traits\GetterTrait\GetActionLogTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -35,7 +36,8 @@ final class CalculateDexAvailabilitiesHandlerTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testHandler(): void
+    #[Test]
+    public function handler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();
@@ -65,7 +67,8 @@ final class CalculateDexAvailabilitiesHandlerTest extends KernelTestCase
         $this->assertEquals($beforeDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testExceptionHandler(): void
+    #[Test]
+    public function exceptionHandler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();

--- a/tests/src/Integration/MessageHandler/CalculateGameBundlesAvailabilitiesHandlerTest.php
+++ b/tests/src/Integration/MessageHandler/CalculateGameBundlesAvailabilitiesHandlerTest.php
@@ -13,6 +13,7 @@ use App\Tests\Common\Traits\GetterTrait\GetActionLogTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -35,7 +36,8 @@ final class CalculateGameBundlesAvailabilitiesHandlerTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testHandler(): void
+    #[Test]
+    public function handler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();
@@ -65,7 +67,8 @@ final class CalculateGameBundlesAvailabilitiesHandlerTest extends KernelTestCase
         $this->assertEquals($beforeDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testExceptionHandler(): void
+    #[Test]
+    public function exceptionHandler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();

--- a/tests/src/Integration/MessageHandler/CalculateGameBundlesShiniesAvailabilitiesHandlerTest.php
+++ b/tests/src/Integration/MessageHandler/CalculateGameBundlesShiniesAvailabilitiesHandlerTest.php
@@ -13,6 +13,7 @@ use App\Tests\Common\Traits\GetterTrait\GetActionLogTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -35,7 +36,8 @@ final class CalculateGameBundlesShiniesAvailabilitiesHandlerTest extends KernelT
         self::bootKernel();
     }
 
-    public function testHandler(): void
+    #[Test]
+    public function handler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();
@@ -65,7 +67,8 @@ final class CalculateGameBundlesShiniesAvailabilitiesHandlerTest extends KernelT
         $this->assertEquals($beforeDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testExceptionHandler(): void
+    #[Test]
+    public function exceptionHandler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();

--- a/tests/src/Integration/MessageHandler/CalculatePokemonAvailabilitiesHandlerTest.php
+++ b/tests/src/Integration/MessageHandler/CalculatePokemonAvailabilitiesHandlerTest.php
@@ -13,6 +13,7 @@ use App\Tests\Common\Traits\GetterTrait\GetActionLogTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -35,7 +36,8 @@ final class CalculatePokemonAvailabilitiesHandlerTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testHandler(): void
+    #[Test]
+    public function handler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();
@@ -65,7 +67,8 @@ final class CalculatePokemonAvailabilitiesHandlerTest extends KernelTestCase
         $this->assertEquals($beforeDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testExceptionHandler(): void
+    #[Test]
+    public function exceptionHandler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();

--- a/tests/src/Integration/MessageHandler/UpdateCollectionsAvailabilitiesHandlerTest.php
+++ b/tests/src/Integration/MessageHandler/UpdateCollectionsAvailabilitiesHandlerTest.php
@@ -13,6 +13,7 @@ use App\Tests\Common\Traits\GetterTrait\GetActionLogTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -35,7 +36,8 @@ final class UpdateCollectionsAvailabilitiesHandlerTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testHandler(): void
+    #[Test]
+    public function handler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();
@@ -65,7 +67,8 @@ final class UpdateCollectionsAvailabilitiesHandlerTest extends KernelTestCase
         $this->assertEquals($beforeDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testExceptionHandler(): void
+    #[Test]
+    public function exceptionHandler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();

--- a/tests/src/Integration/MessageHandler/UpdateGamesAvailabilitiesHandlerTest.php
+++ b/tests/src/Integration/MessageHandler/UpdateGamesAvailabilitiesHandlerTest.php
@@ -13,6 +13,7 @@ use App\Tests\Common\Traits\GetterTrait\GetActionLogTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -35,7 +36,8 @@ final class UpdateGamesAvailabilitiesHandlerTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testHandler(): void
+    #[Test]
+    public function handler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();
@@ -65,7 +67,8 @@ final class UpdateGamesAvailabilitiesHandlerTest extends KernelTestCase
         $this->assertEquals($beforeDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testExceptionHandler(): void
+    #[Test]
+    public function exceptionHandler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();

--- a/tests/src/Integration/MessageHandler/UpdateGamesCollectionsAndDexHandlerTest.php
+++ b/tests/src/Integration/MessageHandler/UpdateGamesCollectionsAndDexHandlerTest.php
@@ -13,6 +13,7 @@ use App\Tests\Common\Traits\GetterTrait\GetActionLogTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -35,7 +36,8 @@ final class UpdateGamesCollectionsAndDexHandlerTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testHandler(): void
+    #[Test]
+    public function handler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();
@@ -73,7 +75,8 @@ final class UpdateGamesCollectionsAndDexHandlerTest extends KernelTestCase
         $this->assertEquals($beforeDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testExceptionHandler(): void
+    #[Test]
+    public function exceptionHandler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();

--- a/tests/src/Integration/MessageHandler/UpdateGamesShiniesAvailabilitiesHandlerTest.php
+++ b/tests/src/Integration/MessageHandler/UpdateGamesShiniesAvailabilitiesHandlerTest.php
@@ -13,6 +13,7 @@ use App\Tests\Common\Traits\GetterTrait\GetActionLogTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -35,7 +36,8 @@ final class UpdateGamesShiniesAvailabilitiesHandlerTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testHandler(): void
+    #[Test]
+    public function handler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();
@@ -65,7 +67,8 @@ final class UpdateGamesShiniesAvailabilitiesHandlerTest extends KernelTestCase
         $this->assertEquals($beforeDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testExceptionHandler(): void
+    #[Test]
+    public function exceptionHandler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();

--- a/tests/src/Integration/MessageHandler/UpdateLabelsHandlerTest.php
+++ b/tests/src/Integration/MessageHandler/UpdateLabelsHandlerTest.php
@@ -13,6 +13,7 @@ use App\Tests\Common\Traits\GetterTrait\GetActionLogTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -35,7 +36,8 @@ final class UpdateLabelsHandlerTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testHandler(): void
+    #[Test]
+    public function handler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();
@@ -77,7 +79,8 @@ final class UpdateLabelsHandlerTest extends KernelTestCase
         $this->assertEquals($beforeDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testExceptionHandler(): void
+    #[Test]
+    public function exceptionHandler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();

--- a/tests/src/Integration/MessageHandler/UpdatePokemonsHandlerTest.php
+++ b/tests/src/Integration/MessageHandler/UpdatePokemonsHandlerTest.php
@@ -13,6 +13,7 @@ use App\Tests\Common\Traits\GetterTrait\GetActionLogTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -35,7 +36,8 @@ final class UpdatePokemonsHandlerTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testHandler(): void
+    #[Test]
+    public function handler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();
@@ -65,7 +67,8 @@ final class UpdatePokemonsHandlerTest extends KernelTestCase
         $this->assertEquals($beforeDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testExceptionHandler(): void
+    #[Test]
+    public function exceptionHandler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();

--- a/tests/src/Integration/MessageHandler/UpdateRegionalDexNumbersHandlerTest.php
+++ b/tests/src/Integration/MessageHandler/UpdateRegionalDexNumbersHandlerTest.php
@@ -13,6 +13,7 @@ use App\Tests\Common\Traits\GetterTrait\GetActionLogTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Zenstruck\Messenger\Test\InteractsWithMessenger;
 
@@ -35,7 +36,8 @@ final class UpdateRegionalDexNumbersHandlerTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testHandler(): void
+    #[Test]
+    public function handler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();
@@ -65,7 +67,8 @@ final class UpdateRegionalDexNumbersHandlerTest extends KernelTestCase
         $this->assertEquals($beforeDoneCount + 1, $this->getActionLogDoneCount());
     }
 
-    public function testExceptionHandler(): void
+    #[Test]
+    public function exceptionHandler(): void
     {
         $transport = $this->transport('async');
         $transport->throwExceptions();

--- a/tests/src/Integration/Repository/ActionLogsRepositoryTest.php
+++ b/tests/src/Integration/Repository/ActionLogsRepositoryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\ActionLogsRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class ActionLogsRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetLastests(): void
+    #[Test]
+    public function getLastests(): void
     {
         $repo = self::getContainer()->get(ActionLogsRepository::class);
 

--- a/tests/src/Integration/Repository/CatchStatesRepositoryTest.php
+++ b/tests/src/Integration/Repository/CatchStatesRepositoryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\CatchStatesRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class CatchStatesRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(CatchStatesRepository::class);
 

--- a/tests/src/Integration/Repository/CategoryFormsRepositoryTest.php
+++ b/tests/src/Integration/Repository/CategoryFormsRepositoryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\CategoryFormsRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class CategoryFormsRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(CategoryFormsRepository::class);
 

--- a/tests/src/Integration/Repository/CollectionsAvailabilitiesRepositoryTest.php
+++ b/tests/src/Integration/Repository/CollectionsAvailabilitiesRepositoryTest.php
@@ -10,6 +10,7 @@ use App\Repository\PokemonsRepository;
 use App\Tests\Common\Traits\CounterTrait\CountCollectionAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -36,7 +37,8 @@ final class CollectionsAvailabilitiesRepositoryTest extends KernelTestCase
         $this->pokemonsRepo = self::getContainer()->get(PokemonsRepository::class);
     }
 
-    public function testRemoveAll(): void
+    #[Test]
+    public function removeAll(): void
     {
         $this->assertGreaterThan(0, $this->getCollectionAvailabilityCount());
 
@@ -48,7 +50,8 @@ final class CollectionsAvailabilitiesRepositoryTest extends KernelTestCase
         $this->assertEquals(0, $this->getCollectionAvailabilityCount());
     }
 
-    public function testGetFromPokemon(): void
+    #[Test]
+    public function getFromPokemon(): void
     {
         $pokemonDouze = $this->getPokemon('Douze');
 

--- a/tests/src/Integration/Repository/CollectionsRepositoryTest.php
+++ b/tests/src/Integration/Repository/CollectionsRepositoryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\CollectionsRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class CollectionsRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetAllSlug(): void
+    #[Test]
+    public function getAllSlug(): void
     {
         $repo = self::getContainer()->get(CollectionsRepository::class);
 
@@ -44,7 +46,8 @@ final class CollectionsRepositoryTest extends KernelTestCase
         );
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(CollectionsRepository::class);
 

--- a/tests/src/Integration/Repository/DexAvailabilitiesRepositoryTest.php
+++ b/tests/src/Integration/Repository/DexAvailabilitiesRepositoryTest.php
@@ -12,6 +12,7 @@ use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -30,7 +31,8 @@ final class DexAvailabilitiesRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testRemoveAll(): void
+    #[Test]
+    public function removeAll(): void
     {
         $this->assertGreaterThan(0, $this->getDexAvailabilityCount());
 
@@ -40,7 +42,8 @@ final class DexAvailabilitiesRepositoryTest extends KernelTestCase
         $this->assertEquals(0, $this->getDexAvailabilityCount());
     }
 
-    public function testGetTotal(): void
+    #[Test]
+    public function getTotal(): void
     {
         $repo = self::getContainer()->get(DexAvailabilitiesRepository::class);
 
@@ -53,7 +56,8 @@ final class DexAvailabilitiesRepositoryTest extends KernelTestCase
         $this->assertEquals(22, $totalCount);
     }
 
-    public function testGetTotalDifferentTrainer(): void
+    #[Test]
+    public function getTotalDifferentTrainer(): void
     {
         $repo = self::getContainer()->get(DexAvailabilitiesRepository::class);
 
@@ -69,8 +73,9 @@ final class DexAvailabilitiesRepositoryTest extends KernelTestCase
     /**
      * @param string[][] $filters
      */
+    #[Test]
     #[DataProvider('providerGetTotalFilters')]
-    public function testGetTotalFilters(array $filters, int $expectedTotalCount): void
+    public function getTotalFilters(array $filters, int $expectedTotalCount): void
     {
         $repo = self::getContainer()->get(DexAvailabilitiesRepository::class);
 
@@ -102,7 +107,8 @@ final class DexAvailabilitiesRepositoryTest extends KernelTestCase
         );
     }
 
-    public function testGetBatchedTotal(): void
+    #[Test]
+    public function getBatchedTotal(): void
     {
         $repo = self::getContainer()->get(DexAvailabilitiesRepository::class);
 
@@ -118,7 +124,8 @@ final class DexAvailabilitiesRepositoryTest extends KernelTestCase
         $this->assertSame(11, $byDexSlug['home_shiny']);
     }
 
-    public function testGetBatchedTotalDifferentTrainer(): void
+    #[Test]
+    public function getBatchedTotalDifferentTrainer(): void
     {
         $repo = self::getContainer()->get(DexAvailabilitiesRepository::class);
 

--- a/tests/src/Integration/Repository/DexRepositoryTest.php
+++ b/tests/src/Integration/Repository/DexRepositoryTest.php
@@ -11,6 +11,7 @@ use App\Tests\Common\Traits\CounterTrait\CountDexTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -28,7 +29,8 @@ final class DexRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(DexRepository::class);
 
@@ -48,7 +50,8 @@ final class DexRepositoryTest extends KernelTestCase
         );
     }
 
-    public function testGetData(): void
+    #[Test]
+    public function getData(): void
     {
         $repo = self::getContainer()->get(DexRepository::class);
 
@@ -83,8 +86,9 @@ final class DexRepositoryTest extends KernelTestCase
     /**
      * @param string[] $expectedSlugs
      */
+    #[Test]
     #[DataProvider('providerGetCanHoldElection')]
-    public function testGetCanHoldElection(
+    public function getCanHoldElection(
         bool $includeUnreleasedDex,
         bool $includePremiumDex,
         array $expectedSlugs,

--- a/tests/src/Integration/Repository/GameBundlesAvailabilitiesRepositoryTest.php
+++ b/tests/src/Integration/Repository/GameBundlesAvailabilitiesRepositoryTest.php
@@ -13,6 +13,7 @@ use App\Repository\PokemonsRepository;
 use App\Tests\Common\Traits\CounterTrait\CountGameBundleAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -44,7 +45,8 @@ final class GameBundlesAvailabilitiesRepositoryTest extends KernelTestCase
         $this->pokemonsRepo = self::getContainer()->get(PokemonsRepository::class);
     }
 
-    public function testRemoveAll(): void
+    #[Test]
+    public function removeAll(): void
     {
         $this->assertGreaterThan(0, $this->getGameBundleAvailabilityCount());
 
@@ -53,7 +55,8 @@ final class GameBundlesAvailabilitiesRepositoryTest extends KernelTestCase
         $this->assertEquals(0, $this->getGameBundleAvailabilityCount());
     }
 
-    public function testCalculate(): void
+    #[Test]
+    public function calculate(): void
     {
         $this->gameBundleAvailabilityRepo->removeAll();
 
@@ -89,7 +92,8 @@ final class GameBundlesAvailabilitiesRepositoryTest extends KernelTestCase
         $this->assertIsNotAvailable('Ruby, Sapphire, Emerald', 'deoxys-attack');
     }
 
-    public function testGetFromPokemon(): void
+    #[Test]
+    public function getFromPokemon(): void
     {
         $pokemonDouze = $this->getPokemon('douze');
 

--- a/tests/src/Integration/Repository/GameBundlesRepositoryTest.php
+++ b/tests/src/Integration/Repository/GameBundlesRepositoryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\GameBundlesRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class GameBundlesRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(GameBundlesRepository::class);
 

--- a/tests/src/Integration/Repository/GameBundlesShiniesAvailabilitiesRepositoryTest.php
+++ b/tests/src/Integration/Repository/GameBundlesShiniesAvailabilitiesRepositoryTest.php
@@ -13,6 +13,7 @@ use App\Repository\PokemonsRepository;
 use App\Tests\Common\Traits\CounterTrait\CountGameBundleShinyAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -44,7 +45,8 @@ final class GameBundlesShiniesAvailabilitiesRepositoryTest extends KernelTestCas
         $this->pokemonsRepo = self::getContainer()->get(PokemonsRepository::class);
     }
 
-    public function testRemoveAll(): void
+    #[Test]
+    public function removeAll(): void
     {
         $this->assertGreaterThan(0, $this->getGameBundleShinyAvailabilityCount());
 
@@ -53,7 +55,8 @@ final class GameBundlesShiniesAvailabilitiesRepositoryTest extends KernelTestCas
         $this->assertEquals(0, $this->getGameBundleShinyAvailabilityCount());
     }
 
-    public function testCalculate(): void
+    #[Test]
+    public function calculate(): void
     {
         $this->gameBundleShinyAvailabilityRepo->removeAll();
 
@@ -89,7 +92,8 @@ final class GameBundlesShiniesAvailabilitiesRepositoryTest extends KernelTestCas
         $this->assertIsNotAvailable('Ruby, Sapphire, Emerald', 'deoxys-attack');
     }
 
-    public function testGetFromPokemon(): void
+    #[Test]
+    public function getFromPokemon(): void
     {
         $pokemonDouze = $this->getPokemon('douze');
 

--- a/tests/src/Integration/Repository/GamesAvailabilitiesRepositoryTest.php
+++ b/tests/src/Integration/Repository/GamesAvailabilitiesRepositoryTest.php
@@ -10,6 +10,7 @@ use App\Repository\PokemonsRepository;
 use App\Tests\Common\Traits\CounterTrait\CountGameAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -36,7 +37,8 @@ final class GamesAvailabilitiesRepositoryTest extends KernelTestCase
         $this->pokemonsRepo = self::getContainer()->get(PokemonsRepository::class);
     }
 
-    public function testRemoveAll(): void
+    #[Test]
+    public function removeAll(): void
     {
         $this->assertGreaterThan(0, $this->getGameAvailabilityCount());
 
@@ -48,7 +50,8 @@ final class GamesAvailabilitiesRepositoryTest extends KernelTestCase
         $this->assertEquals(0, $this->getGameAvailabilityCount());
     }
 
-    public function testGetFromPokemon(): void
+    #[Test]
+    public function getFromPokemon(): void
     {
         $pokemonDouze = $this->getPokemon('Douze');
 

--- a/tests/src/Integration/Repository/GamesRepositoryTest.php
+++ b/tests/src/Integration/Repository/GamesRepositoryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\GamesRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class GamesRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(GamesRepository::class);
 

--- a/tests/src/Integration/Repository/GamesShiniesAvailabilitiesRepositoryTest.php
+++ b/tests/src/Integration/Repository/GamesShiniesAvailabilitiesRepositoryTest.php
@@ -10,6 +10,7 @@ use App\Repository\PokemonsRepository;
 use App\Tests\Common\Traits\CounterTrait\CountGameShinyAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -36,7 +37,8 @@ final class GamesShiniesAvailabilitiesRepositoryTest extends KernelTestCase
         $this->pokemonsRepo = self::getContainer()->get(PokemonsRepository::class);
     }
 
-    public function testRemoveAll(): void
+    #[Test]
+    public function removeAll(): void
     {
         $this->assertGreaterThan(0, $this->getGameShinyAvailabilityCount());
 
@@ -48,7 +50,8 @@ final class GamesShiniesAvailabilitiesRepositoryTest extends KernelTestCase
         $this->assertEquals(0, $this->getGameShinyAvailabilityCount());
     }
 
-    public function testGetFromPokemon(): void
+    #[Test]
+    public function getFromPokemon(): void
     {
         $pokemonDeoxys = $this->getPokemon('Deoxys');
 

--- a/tests/src/Integration/Repository/ImagePipelineRunRepositoryTest.php
+++ b/tests/src/Integration/Repository/ImagePipelineRunRepositoryTest.php
@@ -9,6 +9,7 @@ use App\Repository\ImagePipelineRunRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -25,7 +26,8 @@ final class ImagePipelineRunRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testCreateThenFindLatest(): void
+    #[Test]
+    public function createThenFindLatest(): void
     {
         $repo = self::getContainer()->get(ImagePipelineRunRepository::class);
 
@@ -38,14 +40,16 @@ final class ImagePipelineRunRepositoryTest extends KernelTestCase
         $this->assertNull($run->workflowARunId);
     }
 
-    public function testFindLatestReturnsNullWhenEmpty(): void
+    #[Test]
+    public function findLatestReturnsNullWhenEmpty(): void
     {
         $repo = self::getContainer()->get(ImagePipelineRunRepository::class);
 
         $this->assertNull($repo->findLatest());
     }
 
-    public function testFindLatestReturnsMostRecent(): void
+    #[Test]
+    public function findLatestReturnsMostRecent(): void
     {
         $repo = self::getContainer()->get(ImagePipelineRunRepository::class);
         $entityManager = self::getContainer()->get(EntityManagerInterface::class);
@@ -69,7 +73,8 @@ final class ImagePipelineRunRepositoryTest extends KernelTestCase
         $this->assertSame('corr-newer', $run->correlationId);
     }
 
-    public function testUpdateFieldsAppliesOnlyProvidedFields(): void
+    #[Test]
+    public function updateFieldsAppliesOnlyProvidedFields(): void
     {
         $repo = self::getContainer()->get(ImagePipelineRunRepository::class);
 
@@ -92,7 +97,8 @@ final class ImagePipelineRunRepositoryTest extends KernelTestCase
         $this->assertNull($run->iconPrNumber);
     }
 
-    public function testUpdateFieldsPreservesFieldsFromAnEarlierPatch(): void
+    #[Test]
+    public function updateFieldsPreservesFieldsFromAnEarlierPatch(): void
     {
         $repo = self::getContainer()->get(ImagePipelineRunRepository::class);
 
@@ -108,7 +114,8 @@ final class ImagePipelineRunRepositoryTest extends KernelTestCase
         $this->assertSame(2, $run->iconPrNumber);
     }
 
-    public function testUpdateFieldsAppliesAllProvidedFields(): void
+    #[Test]
+    public function updateFieldsAppliesAllProvidedFields(): void
     {
         $repo = self::getContainer()->get(ImagePipelineRunRepository::class);
 
@@ -152,7 +159,8 @@ final class ImagePipelineRunRepositoryTest extends KernelTestCase
         $this->assertSame('merged', $run->resourcesPrState);
     }
 
-    public function testUpdateFieldsReturnsFalseWhenCorrelationIdUnknown(): void
+    #[Test]
+    public function updateFieldsReturnsFalseWhenCorrelationIdUnknown(): void
     {
         $repo = self::getContainer()->get(ImagePipelineRunRepository::class);
 

--- a/tests/src/Integration/Repository/PokedexRepositoryCatchStateCountTest.php
+++ b/tests/src/Integration/Repository/PokedexRepositoryCatchStateCountTest.php
@@ -12,6 +12,7 @@ use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -30,7 +31,8 @@ final class PokedexRepositoryCatchStateCountTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetCatchStatesCounts(): void
+    #[Test]
+    public function getCatchStatesCounts(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -75,7 +77,8 @@ final class PokedexRepositoryCatchStateCountTest extends KernelTestCase
         );
     }
 
-    public function testGetBatchedCatchStatesCounts(): void
+    #[Test]
+    public function getBatchedCatchStatesCounts(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -104,8 +107,9 @@ final class PokedexRepositoryCatchStateCountTest extends KernelTestCase
      * @param array<string, array<int, string>> $filters
      * @param array<int, int>                   $expectedCounts
      */
+    #[Test]
     #[DataProvider('providerGetCatchStatesCountsFilters')]
-    public function testGetCatchStatesCountsFilters(
+    public function getCatchStatesCountsFilters(
         array $filters,
         array $expectedCounts
     ): void {
@@ -142,7 +146,8 @@ final class PokedexRepositoryCatchStateCountTest extends KernelTestCase
         );
     }
 
-    public function testGetCatchStateCountsDefinedByTrainer(): void
+    #[Test]
+    public function getCatchStateCountsDefinedByTrainer(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -175,7 +180,8 @@ final class PokedexRepositoryCatchStateCountTest extends KernelTestCase
         );
     }
 
-    public function testGetCatchStateUsage(): void
+    #[Test]
+    public function getCatchStateUsage(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 

--- a/tests/src/Integration/Repository/PokedexRepositoryList/CatchsStatesTest.php
+++ b/tests/src/Integration/Repository/PokedexRepositoryList/CatchsStatesTest.php
@@ -12,6 +12,7 @@ use App\Tests\Common\Traits\PokemonListTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -32,7 +33,8 @@ final class CatchsStatesTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetListQueryCatchStates(): void
+    #[Test]
+    public function getListQueryCatchStates(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -56,7 +58,8 @@ final class CatchsStatesTest extends KernelTestCase
         );
     }
 
-    public function testGetListQueryCatchStatesNegative(): void
+    #[Test]
+    public function getListQueryCatchStatesNegative(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -96,7 +99,8 @@ final class CatchsStatesTest extends KernelTestCase
         );
     }
 
-    public function testGetListQueryCatchStatesNegativeNo(): void
+    #[Test]
+    public function getListQueryCatchStatesNegativeNo(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 

--- a/tests/src/Integration/Repository/PokedexRepositoryList/CollectionsTest.php
+++ b/tests/src/Integration/Repository/PokedexRepositoryList/CollectionsTest.php
@@ -12,6 +12,7 @@ use App\Tests\Common\Traits\PokemonListTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -32,7 +33,8 @@ final class CollectionsTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetListQueryCollectionAvailabilities(): void
+    #[Test]
+    public function getListQueryCollectionAvailabilities(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -54,7 +56,8 @@ final class CollectionsTest extends KernelTestCase
         );
     }
 
-    public function testGetListQueryCollectionAvailabilitiesNegative(): void
+    #[Test]
+    public function getListQueryCollectionAvailabilitiesNegative(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 

--- a/tests/src/Integration/Repository/PokedexRepositoryList/FamiliesTest.php
+++ b/tests/src/Integration/Repository/PokedexRepositoryList/FamiliesTest.php
@@ -12,6 +12,7 @@ use App\Tests\Common\Traits\PokemonListTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -32,7 +33,8 @@ final class FamiliesTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetListQueryFamilies(): void
+    #[Test]
+    public function getListQueryFamilies(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 

--- a/tests/src/Integration/Repository/PokedexRepositoryList/FormsTest.php
+++ b/tests/src/Integration/Repository/PokedexRepositoryList/FormsTest.php
@@ -12,6 +12,7 @@ use App\Tests\Common\Traits\PokemonListTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -32,7 +33,8 @@ final class FormsTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetListQueryCategoryForm(): void
+    #[Test]
+    public function getListQueryCategoryForm(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -55,7 +57,8 @@ final class FormsTest extends KernelTestCase
         );
     }
 
-    public function testGetListQueryRegionalForm(): void
+    #[Test]
+    public function getListQueryRegionalForm(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -79,7 +82,8 @@ final class FormsTest extends KernelTestCase
         );
     }
 
-    public function testGetListQuerySpecialForm(): void
+    #[Test]
+    public function getListQuerySpecialForm(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -102,7 +106,8 @@ final class FormsTest extends KernelTestCase
         );
     }
 
-    public function testGetListQuerySpecialsForm(): void
+    #[Test]
+    public function getListQuerySpecialsForm(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -127,7 +132,8 @@ final class FormsTest extends KernelTestCase
         );
     }
 
-    public function testGetListQueryVariantForm(): void
+    #[Test]
+    public function getListQueryVariantForm(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 

--- a/tests/src/Integration/Repository/PokedexRepositoryList/GamesTest.php
+++ b/tests/src/Integration/Repository/PokedexRepositoryList/GamesTest.php
@@ -12,6 +12,7 @@ use App\Tests\Common\Traits\PokemonListTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -32,7 +33,8 @@ final class GamesTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetListQueryOriginalGameBundle(): void
+    #[Test]
+    public function getListQueryOriginalGameBundle(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -65,7 +67,8 @@ final class GamesTest extends KernelTestCase
         );
     }
 
-    public function testGetListQueryGameBundleAvailabilities(): void
+    #[Test]
+    public function getListQueryGameBundleAvailabilities(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -88,7 +91,8 @@ final class GamesTest extends KernelTestCase
         );
     }
 
-    public function testGetListQueryGameBundleAvailabilitiesNegative(): void
+    #[Test]
+    public function getListQueryGameBundleAvailabilitiesNegative(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -129,7 +133,8 @@ final class GamesTest extends KernelTestCase
         );
     }
 
-    public function testGetListQueryGameBundleShinyAvailabilities(): void
+    #[Test]
+    public function getListQueryGameBundleShinyAvailabilities(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -154,7 +159,8 @@ final class GamesTest extends KernelTestCase
         );
     }
 
-    public function testGetListQueryGameBundleShinyAvailabilitiesNegative(): void
+    #[Test]
+    public function getListQueryGameBundleShinyAvailabilitiesNegative(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 

--- a/tests/src/Integration/Repository/PokedexRepositoryList/GenericTest.php
+++ b/tests/src/Integration/Repository/PokedexRepositoryList/GenericTest.php
@@ -11,6 +11,7 @@ use App\Tests\Common\Traits\GetterTrait\GetPokedexTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -30,7 +31,8 @@ final class GenericTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetListQuery(): void
+    #[Test]
+    public function getListQuery(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 

--- a/tests/src/Integration/Repository/PokedexRepositoryList/TypesTest.php
+++ b/tests/src/Integration/Repository/PokedexRepositoryList/TypesTest.php
@@ -12,6 +12,7 @@ use App\Tests\Common\Traits\PokemonListTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -32,7 +33,8 @@ final class TypesTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetListQueryPrimaryTypeFilter(): void
+    #[Test]
+    public function getListQueryPrimaryTypeFilter(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -59,7 +61,8 @@ final class TypesTest extends KernelTestCase
         );
     }
 
-    public function testGetListQuerySecondaryTypeFilter(): void
+    #[Test]
+    public function getListQuerySecondaryTypeFilter(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -83,7 +86,8 @@ final class TypesTest extends KernelTestCase
         );
     }
 
-    public function testGetListQueryPrimaryAndSecondaryTypeFilter(): void
+    #[Test]
+    public function getListQueryPrimaryAndSecondaryTypeFilter(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -110,7 +114,8 @@ final class TypesTest extends KernelTestCase
         );
     }
 
-    public function testGetListQueryAnyTypeFilter(): void
+    #[Test]
+    public function getListQueryAnyTypeFilter(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 

--- a/tests/src/Integration/Repository/PokedexRepositoryTest.php
+++ b/tests/src/Integration/Repository/PokedexRepositoryTest.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Connection;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -31,7 +32,8 @@ final class PokedexRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testUpdate(): void
+    #[Test]
+    public function update(): void
     {
         $pokedexBefore = $this->getPokedexFromSlugs('redgreenblueyellow', 'ivysaur');
 
@@ -48,7 +50,8 @@ final class PokedexRepositoryTest extends KernelTestCase
         $this->assertEquals('maybe', $pokedexAfter['slug']);
     }
 
-    public function testInsert(): void
+    #[Test]
+    public function insert(): void
     {
         $pokedexBefore = $this->getPokedexFromSlugs('goldsilvercrystal', 'douze');
 
@@ -64,7 +67,8 @@ final class PokedexRepositoryTest extends KernelTestCase
         $this->assertEquals('maybenot', $pokedexAfter['slug']);
     }
 
-    public function testUpsertReturnsTheWrittenTrainerDexIdWhenCatchStateChanges(): void
+    #[Test]
+    public function upsertReturnsTheWrittenTrainerDexIdWhenCatchStateChanges(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
         $trainerDexId = $this->getTrainerDexId('goldsilvercrystal');
@@ -75,7 +79,8 @@ final class PokedexRepositoryTest extends KernelTestCase
         $this->assertSame($trainerDexId, $result);
     }
 
-    public function testUpsertReturnsNullWhenCatchStateIsUnchanged(): void
+    #[Test]
+    public function upsertReturnsNullWhenCatchStateIsUnchanged(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -85,7 +90,8 @@ final class PokedexRepositoryTest extends KernelTestCase
         $this->assertNull($result);
     }
 
-    public function testUpsertReturnsNullWhenDexSlugDoesNotResolveForThisTrainer(): void
+    #[Test]
+    public function upsertReturnsNullWhenDexSlugDoesNotResolveForThisTrainer(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 
@@ -96,7 +102,8 @@ final class PokedexRepositoryTest extends KernelTestCase
         $this->assertNull($result);
     }
 
-    public function testGetDexUsage(): void
+    #[Test]
+    public function getDexUsage(): void
     {
         $repo = self::getContainer()->get(PokedexRepository::class);
 

--- a/tests/src/Integration/Repository/PokedexRepositoryUpsertIfDifferentTest.php
+++ b/tests/src/Integration/Repository/PokedexRepositoryUpsertIfDifferentTest.php
@@ -8,6 +8,7 @@ use App\Repository\PokedexRepository;
 use Doctrine\DBAL\Connection;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -20,7 +21,8 @@ final class PokedexRepositoryUpsertIfDifferentTest extends KernelTestCase
 
     private const string TRAINER = '7b52009b64fd0a2a49e6d8a939753077792b0554';
 
-    public function testReturnsTrueAndWritesWhenValueChanges(): void
+    #[Test]
+    public function returnsTrueAndWritesWhenValueChanges(): void
     {
         $repository = self::getContainer()->get(PokedexRepository::class);
         $trainerDexId = $this->getTrainerDexId('goldsilvercrystal');
@@ -32,7 +34,8 @@ final class PokedexRepositoryUpsertIfDifferentTest extends KernelTestCase
         $this->assertSame('yes', $this->getCatchStateSlug($trainerDexId, 'ivysaur'));
     }
 
-    public function testReturnsFalseAndDoesNotWriteWhenValueIsUnchanged(): void
+    #[Test]
+    public function returnsFalseAndDoesNotWriteWhenValueIsUnchanged(): void
     {
         $repository = self::getContainer()->get(PokedexRepository::class);
         $trainerDexId = $this->getTrainerDexId('goldsilvercrystal');
@@ -44,7 +47,8 @@ final class PokedexRepositoryUpsertIfDifferentTest extends KernelTestCase
         $this->assertSame('no', $this->getCatchStateSlug($trainerDexId, 'ivysaur'));
     }
 
-    public function testReturnsFalseWhenPokemonNotInDex(): void
+    #[Test]
+    public function returnsFalseWhenPokemonNotInDex(): void
     {
         $repository = self::getContainer()->get(PokedexRepository::class);
         // Fixture: 'douze' has no dex_availability row for goldsilvercrystal (only redgreenblueyellow and home).
@@ -56,7 +60,8 @@ final class PokedexRepositoryUpsertIfDifferentTest extends KernelTestCase
         $this->assertNull($this->getCatchStateSlug($trainerDexId, 'douze'));
     }
 
-    public function testCreatesAFreshPokedexRowWhenNoneExists(): void
+    #[Test]
+    public function createsAFreshPokedexRowWhenNoneExists(): void
     {
         $repository = self::getContainer()->get(PokedexRepository::class);
         // Fixture: 'douze' has a dex_availability row for redgreenblueyellow but no pokedex row for it yet.

--- a/tests/src/Integration/Repository/PokemonAvailabilitiesRepositoryTest.php
+++ b/tests/src/Integration/Repository/PokemonAvailabilitiesRepositoryTest.php
@@ -9,6 +9,7 @@ use App\Tests\Common\Traits\CounterTrait\CountPokemonAvailabilitiesTrait;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -26,7 +27,8 @@ final class PokemonAvailabilitiesRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testRemoveAllByCategory(): void
+    #[Test]
+    public function removeAllByCategory(): void
     {
         $this->assertGreaterThan(0, $this->getPokemonAvailabilitiesCount('game_bundle'));
         $previousCount = $this->getPokemonAvailabilitiesCount('game_bundle_shiny');
@@ -42,7 +44,8 @@ final class PokemonAvailabilitiesRepositoryTest extends KernelTestCase
         );
     }
 
-    public function testCalculateGameBundle(): void
+    #[Test]
+    public function calculateGameBundle(): void
     {
         $repo = self::getContainer()->get(PokemonAvailabilitiesRepository::class);
 
@@ -61,7 +64,8 @@ final class PokemonAvailabilitiesRepositoryTest extends KernelTestCase
         );
     }
 
-    public function testCalculateGameBundleShiny(): void
+    #[Test]
+    public function calculateGameBundleShiny(): void
     {
         $repo = self::getContainer()->get(PokemonAvailabilitiesRepository::class);
 
@@ -80,7 +84,8 @@ final class PokemonAvailabilitiesRepositoryTest extends KernelTestCase
         );
     }
 
-    public function testCalculateUnicity(): void
+    #[Test]
+    public function calculateUnicity(): void
     {
         $repo = self::getContainer()->get(PokemonAvailabilitiesRepository::class);
 

--- a/tests/src/Integration/Repository/PokemonsRepositoryTest.php
+++ b/tests/src/Integration/Repository/PokemonsRepositoryTest.php
@@ -11,6 +11,7 @@ use App\Tests\Common\Traits\CounterTrait\CountPokemonTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -28,7 +29,8 @@ final class PokemonsRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testRemoveAll(): void
+    #[Test]
+    public function removeAll(): void
     {
         $initCount = $this->getPokemonCount();
         $this->assertGreaterThan(0, $initCount);
@@ -50,7 +52,8 @@ final class PokemonsRepositoryTest extends KernelTestCase
         $this->assertEquals(0, $this->getPokemonNotDeletedCount());
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(PokemonsRepository::class);
 
@@ -81,8 +84,9 @@ final class PokemonsRepositoryTest extends KernelTestCase
     /**
      * @param string[][] $filters
      */
+    #[Test]
     #[DataProvider('providerGetNToPick')]
-    public function testGetNToPick(
+    public function getNToPick(
         string $dexSlug,
         string $electionSlug,
         array $filters,
@@ -169,8 +173,9 @@ final class PokemonsRepositoryTest extends KernelTestCase
     /**
      * @param string[][] $filters
      */
+    #[Test]
     #[DataProvider('providerGetNToVote')]
-    public function testGetNToVote(
+    public function getNToVote(
         string $dexSlug,
         string $electionSlug,
         array $filters,

--- a/tests/src/Integration/Repository/RegionalFormsRepositoryTest.php
+++ b/tests/src/Integration/Repository/RegionalFormsRepositoryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\RegionalFormsRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class RegionalFormsRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(RegionalFormsRepository::class);
 

--- a/tests/src/Integration/Repository/RegionsRepositoryTest.php
+++ b/tests/src/Integration/Repository/RegionsRepositoryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\RegionsRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class RegionsRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(RegionsRepository::class);
 

--- a/tests/src/Integration/Repository/SpecialFormsRepositoryTest.php
+++ b/tests/src/Integration/Repository/SpecialFormsRepositoryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\SpecialFormsRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class SpecialFormsRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(SpecialFormsRepository::class);
 

--- a/tests/src/Integration/Repository/TrainerDexLinkRepositoryTest.php
+++ b/tests/src/Integration/Repository/TrainerDexLinkRepositoryTest.php
@@ -8,6 +8,7 @@ use App\Repository\TrainerDexLinkRepository;
 use Doctrine\DBAL\Connection;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Uid\Uuid;
 
@@ -21,7 +22,8 @@ final class TrainerDexLinkRepositoryTest extends KernelTestCase
 
     private const string TRAINER = '7b52009b64fd0a2a49e6d8a939753077792b0554';
 
-    public function testInsertExistsAndGetOutgoingEdges(): void
+    #[Test]
+    public function insertExistsAndGetOutgoingEdges(): void
     {
         $repository = self::getContainer()->get(TrainerDexLinkRepository::class);
 
@@ -42,7 +44,8 @@ final class TrainerDexLinkRepositoryTest extends KernelTestCase
         );
     }
 
-    public function testGetOutgoingEdgesEmptyWhenNoLink(): void
+    #[Test]
+    public function getOutgoingEdgesEmptyWhenNoLink(): void
     {
         $repository = self::getContainer()->get(TrainerDexLinkRepository::class);
 
@@ -51,7 +54,8 @@ final class TrainerDexLinkRepositoryTest extends KernelTestCase
         $this->assertSame([], $repository->getOutgoingEdges(self::TRAINER, $sourceId));
     }
 
-    public function testGetForDexUnidirectional(): void
+    #[Test]
+    public function getForDexUnidirectional(): void
     {
         $repository = self::getContainer()->get(TrainerDexLinkRepository::class);
 
@@ -72,7 +76,8 @@ final class TrainerDexLinkRepositoryTest extends KernelTestCase
         $this->assertSame('redgreenblueyellow', $fromTarget[0]['target_dex_slug']);
     }
 
-    public function testGetForDexBidirectionalIsMergedIntoOneRow(): void
+    #[Test]
+    public function getForDexBidirectionalIsMergedIntoOneRow(): void
     {
         $repository = self::getContainer()->get(TrainerDexLinkRepository::class);
 
@@ -93,7 +98,8 @@ final class TrainerDexLinkRepositoryTest extends KernelTestCase
         $this->assertSame('both', $fromTarget[0]['direction']);
     }
 
-    public function testDeleteByIdOrPairIdDeletesOnlyItselfWhenUnidirectional(): void
+    #[Test]
+    public function deleteByIdOrPairIdDeletesOnlyItselfWhenUnidirectional(): void
     {
         $repository = self::getContainer()->get(TrainerDexLinkRepository::class);
 
@@ -108,7 +114,8 @@ final class TrainerDexLinkRepositoryTest extends KernelTestCase
         $this->assertFalse($repository->exists($sourceId, $targetId));
     }
 
-    public function testDeleteByIdOrPairIdDeletesBothRowsWhenBidirectional(): void
+    #[Test]
+    public function deleteByIdOrPairIdDeletesBothRowsWhenBidirectional(): void
     {
         $repository = self::getContainer()->get(TrainerDexLinkRepository::class);
 

--- a/tests/src/Integration/Repository/TrainerDexRepositoryInsertIfNeededTest.php
+++ b/tests/src/Integration/Repository/TrainerDexRepositoryInsertIfNeededTest.php
@@ -8,6 +8,7 @@ use App\Repository\TrainerDexRepository;
 use App\Tests\Common\Traits\CounterTrait\CountTrainerDexTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -25,7 +26,8 @@ final class TrainerDexRepositoryInsertIfNeededTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testWasNeeded(): void
+    #[Test]
+    public function wasNeeded(): void
     {
         $repo = self::getContainer()->get(TrainerDexRepository::class);
 
@@ -36,7 +38,8 @@ final class TrainerDexRepositoryInsertIfNeededTest extends KernelTestCase
         $this->assertEquals(35, $this->getTrainerDexCount());
     }
 
-    public function testWasntNeeded(): void
+    #[Test]
+    public function wasntNeeded(): void
     {
         $repo = self::getContainer()->get(TrainerDexRepository::class);
 
@@ -47,7 +50,8 @@ final class TrainerDexRepositoryInsertIfNeededTest extends KernelTestCase
         $this->assertEquals(34, $this->getTrainerDexCount());
     }
 
-    public function testWasNeededThenWasnt(): void
+    #[Test]
+    public function wasNeededThenWasnt(): void
     {
         $repo = self::getContainer()->get(TrainerDexRepository::class);
 
@@ -62,7 +66,8 @@ final class TrainerDexRepositoryInsertIfNeededTest extends KernelTestCase
         $this->assertEquals(35, $this->getTrainerDexCount());
     }
 
-    public function testlugOkThenKo(): void
+    #[Test]
+    public function lugOkThenKo(): void
     {
         $repo = self::getContainer()->get(TrainerDexRepository::class);
 

--- a/tests/src/Integration/Repository/TrainerDexRepositoryListQueryTest.php
+++ b/tests/src/Integration/Repository/TrainerDexRepositoryListQueryTest.php
@@ -9,6 +9,7 @@ use App\Repository\TrainerDexRepository;
 use App\Tests\Common\Traits\CounterTrait\CountTrainerDexTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -26,7 +27,8 @@ final class TrainerDexRepositoryListQueryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetListQueryDefault(): void
+    #[Test]
+    public function getListQueryDefault(): void
     {
         $repo = self::getContainer()->get(TrainerDexRepository::class);
 
@@ -38,7 +40,8 @@ final class TrainerDexRepositoryListQueryTest extends KernelTestCase
         $this->assertCount(6, iterator_to_array($list, false));
     }
 
-    public function testGetListQueryWithUnreleased(): void
+    #[Test]
+    public function getListQueryWithUnreleased(): void
     {
         $repo = self::getContainer()->get(TrainerDexRepository::class);
 
@@ -50,7 +53,8 @@ final class TrainerDexRepositoryListQueryTest extends KernelTestCase
         $this->assertCount(10, iterator_to_array($list, false));
     }
 
-    public function testGetListQueryWithPremium(): void
+    #[Test]
+    public function getListQueryWithPremium(): void
     {
         $repo = self::getContainer()->get(TrainerDexRepository::class);
 
@@ -62,7 +66,8 @@ final class TrainerDexRepositoryListQueryTest extends KernelTestCase
         $this->assertCount(7, iterator_to_array($list, false));
     }
 
-    public function testGetListQueryWithUnreleasedAndPremium(): void
+    #[Test]
+    public function getListQueryWithUnreleasedAndPremium(): void
     {
         $repo = self::getContainer()->get(TrainerDexRepository::class);
 

--- a/tests/src/Integration/Repository/TrainerDexRepositorySetTest.php
+++ b/tests/src/Integration/Repository/TrainerDexRepositorySetTest.php
@@ -9,6 +9,7 @@ use App\Repository\TrainerDexRepository;
 use App\Tests\Common\Traits\CounterTrait\CountTrainerDexTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -26,7 +27,8 @@ final class TrainerDexRepositorySetTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testExistingTrainerDex(): void
+    #[Test]
+    public function existingTrainerDex(): void
     {
         $repo = self::getContainer()->get(TrainerDexRepository::class);
 
@@ -41,7 +43,8 @@ final class TrainerDexRepositorySetTest extends KernelTestCase
         $this->assertEquals(34, $this->getTrainerDexCount());
     }
 
-    public function testNewTrainerDex(): void
+    #[Test]
+    public function newTrainerDex(): void
     {
         $repo = self::getContainer()->get(TrainerDexRepository::class);
 
@@ -56,7 +59,8 @@ final class TrainerDexRepositorySetTest extends KernelTestCase
         $this->assertEquals(35, $this->getTrainerDexCount());
     }
 
-    public function testExistingCustomTrainerDex(): void
+    #[Test]
+    public function existingCustomTrainerDex(): void
     {
         $repo = self::getContainer()->get(TrainerDexRepository::class);
 

--- a/tests/src/Integration/Repository/TrainerPokemonEloRepositoryGetEloTest.php
+++ b/tests/src/Integration/Repository/TrainerPokemonEloRepositoryGetEloTest.php
@@ -8,6 +8,7 @@ use App\Repository\TrainerPokemonEloRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -24,8 +25,9 @@ final class TrainerPokemonEloRepositoryGetEloTest extends KernelTestCase
         self::bootKernel();
     }
 
+    #[Test]
     #[DataProvider('providerGetElo')]
-    public function testGetElo(string $pokemonSlug, ?int $expectedElo): void
+    public function getElo(string $pokemonSlug, ?int $expectedElo): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 

--- a/tests/src/Integration/Repository/TrainerPokemonEloRepositoryMetricsTest.php
+++ b/tests/src/Integration/Repository/TrainerPokemonEloRepositoryMetricsTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\TrainerPokemonEloRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class TrainerPokemonEloRepositoryMetricsTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetMetrics(): void
+    #[Test]
+    public function getMetrics(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 
@@ -43,7 +45,8 @@ final class TrainerPokemonEloRepositoryMetricsTest extends KernelTestCase
         );
     }
 
-    public function testGetMetricsBis(): void
+    #[Test]
+    public function getMetricsBis(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 
@@ -63,7 +66,8 @@ final class TrainerPokemonEloRepositoryMetricsTest extends KernelTestCase
         );
     }
 
-    public function testGetMetricsNo(): void
+    #[Test]
+    public function getMetricsNo(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 

--- a/tests/src/Integration/Repository/TrainerPokemonEloRepositoryTopNTest.php
+++ b/tests/src/Integration/Repository/TrainerPokemonEloRepositoryTopNTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\TrainerPokemonEloRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class TrainerPokemonEloRepositoryTopNTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testTop5(): void
+    #[Test]
+    public function top5(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 
@@ -59,7 +61,8 @@ final class TrainerPokemonEloRepositoryTopNTest extends KernelTestCase
         );
     }
 
-    public function testTop5Home(): void
+    #[Test]
+    public function top5Home(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 
@@ -71,7 +74,8 @@ final class TrainerPokemonEloRepositoryTopNTest extends KernelTestCase
         );
     }
 
-    public function testTop5HomeFavorite(): void
+    #[Test]
+    public function top5HomeFavorite(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 
@@ -107,7 +111,8 @@ final class TrainerPokemonEloRepositoryTopNTest extends KernelTestCase
         );
     }
 
-    public function testTop10(): void
+    #[Test]
+    public function top10(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 
@@ -145,7 +150,8 @@ final class TrainerPokemonEloRepositoryTopNTest extends KernelTestCase
         );
     }
 
-    public function testTopComplete(): void
+    #[Test]
+    public function topComplete(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 

--- a/tests/src/Integration/Repository/TrainerPokemonEloRepositoryUpdateEloTest.php
+++ b/tests/src/Integration/Repository/TrainerPokemonEloRepositoryUpdateEloTest.php
@@ -8,6 +8,7 @@ use App\Repository\TrainerPokemonEloRepository;
 use App\Tests\Common\Traits\GetterTrait\GetTrainerPokemonEloTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -25,7 +26,8 @@ final class TrainerPokemonEloRepositoryUpdateEloTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testUpdateElo(): void
+    #[Test]
+    public function updateElo(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 
@@ -41,7 +43,8 @@ final class TrainerPokemonEloRepositoryUpdateEloTest extends KernelTestCase
         );
     }
 
-    public function testUpdateNewElo(): void
+    #[Test]
+    public function updateNewElo(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 
@@ -57,7 +60,8 @@ final class TrainerPokemonEloRepositoryUpdateEloTest extends KernelTestCase
         );
     }
 
-    public function testUpdateWinnerAgain(): void
+    #[Test]
+    public function updateWinnerAgain(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 
@@ -73,7 +77,8 @@ final class TrainerPokemonEloRepositoryUpdateEloTest extends KernelTestCase
         );
     }
 
-    public function testUpdateLoserAgain(): void
+    #[Test]
+    public function updateLoserAgain(): void
     {
         $repo = self::getContainer()->get(TrainerPokemonEloRepository::class);
 

--- a/tests/src/Integration/Repository/TypesRepositoryTest.php
+++ b/tests/src/Integration/Repository/TypesRepositoryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\TypesRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class TypesRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(TypesRepository::class);
 

--- a/tests/src/Integration/Repository/VariantFormsRepositoryTest.php
+++ b/tests/src/Integration/Repository/VariantFormsRepositoryTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Integration\Repository;
 use App\Repository\VariantFormsRepository;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -23,7 +24,8 @@ final class VariantFormsRepositoryTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetAll(): void
+    #[Test]
+    public function getAll(): void
     {
         $repo = self::getContainer()->get(VariantFormsRepository::class);
 

--- a/tests/src/Integration/Service/Album/AlbumDexServiceTest.php
+++ b/tests/src/Integration/Service/Album/AlbumDexServiceTest.php
@@ -8,6 +8,7 @@ use App\Service\Album\AlbumDexService;
 use App\Tests\Common\Traits\CounterTrait\CountGameBundleAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -25,7 +26,8 @@ final class AlbumDexServiceTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $service = self::getContainer()->get(AlbumDexService::class);
 

--- a/tests/src/Integration/Service/Album/AlbumPokemonServiceFilteredTest.php
+++ b/tests/src/Integration/Service/Album/AlbumPokemonServiceFilteredTest.php
@@ -11,6 +11,7 @@ use App\Tests\Common\Traits\PokemonListTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -29,7 +30,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testListFilteredPrimaryType(): void
+    #[Test]
+    public function listFilteredPrimaryType(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -58,7 +60,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredSecondaryType(): void
+    #[Test]
+    public function listFilteredSecondaryType(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -82,7 +85,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredPrimaryAndSecondaryType(): void
+    #[Test]
+    public function listFilteredPrimaryAndSecondaryType(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -109,7 +113,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredAnyType(): void
+    #[Test]
+    public function listFilteredAnyType(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -137,7 +142,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredCategoryType(): void
+    #[Test]
+    public function listFilteredCategoryType(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -160,7 +166,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredRegionalType(): void
+    #[Test]
+    public function listFilteredRegionalType(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -184,7 +191,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredSpecialType(): void
+    #[Test]
+    public function listFilteredSpecialType(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -207,7 +215,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredSpecialsType(): void
+    #[Test]
+    public function listFilteredSpecialsType(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -232,7 +241,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredVariantType(): void
+    #[Test]
+    public function listFilteredVariantType(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -257,7 +267,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredCatchStates(): void
+    #[Test]
+    public function listFilteredCatchStates(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -281,7 +292,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredOriginalGameBundle(): void
+    #[Test]
+    public function listFilteredOriginalGameBundle(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -314,7 +326,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredGameBundleAvailabilities(): void
+    #[Test]
+    public function listFilteredGameBundleAvailabilities(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -337,7 +350,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredGameBundleShinyAvailabilities(): void
+    #[Test]
+    public function listFilteredGameBundleShinyAvailabilities(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -362,7 +376,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredFamilies(): void
+    #[Test]
+    public function listFilteredFamilies(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -389,7 +404,8 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
-    public function testListFilteredCollections(): void
+    #[Test]
+    public function listFilteredCollections(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -411,8 +427,9 @@ final class AlbumPokemonServiceFilteredTest extends KernelTestCase
         );
     }
 
+    #[Test]
     #[DataProvider('providerListFilteredNull')]
-    public function testListFilteredNull(string $filter, int $expectedCount): void
+    public function listFilteredNull(string $filter, int $expectedCount): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 

--- a/tests/src/Integration/Service/Album/AlbumPokemonServiceTest.php
+++ b/tests/src/Integration/Service/Album/AlbumPokemonServiceTest.php
@@ -10,6 +10,7 @@ use App\Tests\Common\Data\AlbumData;
 use App\Tests\Common\Traits\CounterTrait\CountGameBundleAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -27,7 +28,8 @@ final class AlbumPokemonServiceTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testListUser12RedGreenBlueYellow(): void
+    #[Test]
+    public function listUser12RedGreenBlueYellow(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -51,7 +53,8 @@ final class AlbumPokemonServiceTest extends KernelTestCase
         );
     }
 
-    public function testListUser12GoldSilverCrystal(): void
+    #[Test]
+    public function listUser12GoldSilverCrystal(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -77,7 +80,8 @@ final class AlbumPokemonServiceTest extends KernelTestCase
         );
     }
 
-    public function testListUser13(): void
+    #[Test]
+    public function listUser13(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 
@@ -101,7 +105,8 @@ final class AlbumPokemonServiceTest extends KernelTestCase
         );
     }
 
-    public function testListUserUnknown(): void
+    #[Test]
+    public function listUserUnknown(): void
     {
         $service = self::getContainer()->get(AlbumPokemonService::class);
 

--- a/tests/src/Integration/Service/Album/AlbumReportServiceTest.php
+++ b/tests/src/Integration/Service/Album/AlbumReportServiceTest.php
@@ -11,6 +11,7 @@ use App\Tests\Common\Traits\CounterTrait\CountGameBundleAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -28,8 +29,9 @@ final class AlbumReportServiceTest extends KernelTestCase
         self::bootKernel();
     }
 
+    #[Test]
     #[DataProvider('providerGetReport')]
-    public function testGetReport(
+    public function getReport(
         string $trainerId,
         string $dexSlug,
         int $countNo,
@@ -118,8 +120,9 @@ final class AlbumReportServiceTest extends KernelTestCase
     /**
      * @param array<string, array<int, string>> $filters
      */
+    #[Test]
     #[DataProvider('providerGetReportFiltered')]
-    public function testGetReportFiltered(
+    public function getReportFiltered(
         string $trainerId,
         string $dexSlug,
         array $filters,
@@ -160,7 +163,8 @@ final class AlbumReportServiceTest extends KernelTestCase
         );
     }
 
-    public function testGetBatch(): void
+    #[Test]
+    public function getBatch(): void
     {
         $service = self::getContainer()->get(AlbumReportService::class);
 
@@ -176,7 +180,8 @@ final class AlbumReportServiceTest extends KernelTestCase
         $this->assertReport($reports['goldsilvercrystal'], 8, 0, 0, 1, 9);
     }
 
-    public function testGetBatchDifferentTrainer(): void
+    #[Test]
+    public function getBatchDifferentTrainer(): void
     {
         $service = self::getContainer()->get(AlbumReportService::class);
 

--- a/tests/src/Integration/Service/CollectionsAvailabilitiesServiceTest.php
+++ b/tests/src/Integration/Service/CollectionsAvailabilitiesServiceTest.php
@@ -10,6 +10,7 @@ use App\Service\CollectionsAvailabilitiesService;
 use App\Tests\Common\Traits\CounterTrait\CountCollectionAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -27,7 +28,8 @@ final class CollectionsAvailabilitiesServiceTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetFromPokemon(): void
+    #[Test]
+    public function getFromPokemon(): void
     {
         $service = self::getContainer()->get(CollectionsAvailabilitiesService::class);
 

--- a/tests/src/Integration/Service/Election/ElectionReportServiceTest.php
+++ b/tests/src/Integration/Service/Election/ElectionReportServiceTest.php
@@ -8,6 +8,7 @@ use App\DTO\DexQueryOptions;
 use App\Service\Election\ElectionReportService;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -26,7 +27,8 @@ final class ElectionReportServiceTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetReturnsTopAndMetricsForDemoDex(): void
+    #[Test]
+    public function getReturnsTopAndMetricsForDemoDex(): void
     {
         $service = self::getContainer()->get(ElectionReportService::class);
 
@@ -47,7 +49,8 @@ final class ElectionReportServiceTest extends KernelTestCase
         );
     }
 
-    public function testGetReturnsTopAndMetricsForAffineeElection(): void
+    #[Test]
+    public function getReturnsTopAndMetricsForAffineeElection(): void
     {
         $service = self::getContainer()->get(ElectionReportService::class);
 
@@ -67,7 +70,8 @@ final class ElectionReportServiceTest extends KernelTestCase
         );
     }
 
-    public function testGetReturnsZeroedMetricsForUnknownElectionSlug(): void
+    #[Test]
+    public function getReturnsZeroedMetricsForUnknownElectionSlug(): void
     {
         $service = self::getContainer()->get(ElectionReportService::class);
 
@@ -87,7 +91,8 @@ final class ElectionReportServiceTest extends KernelTestCase
         );
     }
 
-    public function testGetEligibleDexDefaultsToReleasedNonPremium(): void
+    #[Test]
+    public function getEligibleDexDefaultsToReleasedNonPremium(): void
     {
         $service = self::getContainer()->get(ElectionReportService::class);
 
@@ -103,7 +108,8 @@ final class ElectionReportServiceTest extends KernelTestCase
         $this->assertSame(['home'], $slugs);
     }
 
-    public function testGetEligibleDexWithAllOptions(): void
+    #[Test]
+    public function getEligibleDexWithAllOptions(): void
     {
         $service = self::getContainer()->get(ElectionReportService::class);
 
@@ -124,7 +130,8 @@ final class ElectionReportServiceTest extends KernelTestCase
         $this->assertSame(['homepogo', 'home', 'redgreenblueyellow', 'spoon'], $slugs);
     }
 
-    public function testGetBatchKeyedByDexSlug(): void
+    #[Test]
+    public function getBatchKeyedByDexSlug(): void
     {
         $service = self::getContainer()->get(ElectionReportService::class);
 

--- a/tests/src/Integration/Service/ElectionServiceTest.php
+++ b/tests/src/Integration/Service/ElectionServiceTest.php
@@ -8,6 +8,7 @@ use App\DTO\ElectionVote;
 use App\Service\ElectionService;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -24,7 +25,8 @@ final class ElectionServiceTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testVote(): void
+    #[Test]
+    public function vote(): void
     {
         $service = self::getContainer()->get(ElectionService::class);
 
@@ -52,7 +54,8 @@ final class ElectionServiceTest extends KernelTestCase
         $this->assertSame(1013, $pokemonsElo['losers'][1]->getElo());
     }
 
-    public function testVoteBis(): void
+    #[Test]
+    public function voteBis(): void
     {
         $service = self::getContainer()->get(ElectionService::class);
 

--- a/tests/src/Integration/Service/ElectionUpdateEloServiceTest.php
+++ b/tests/src/Integration/Service/ElectionUpdateEloServiceTest.php
@@ -9,6 +9,7 @@ use App\Service\ElectionUpdateEloService;
 use App\Tests\Common\Traits\GetterTrait\GetTrainerPokemonEloTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -26,7 +27,8 @@ final class ElectionUpdateEloServiceTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testVote(): void
+    #[Test]
+    public function vote(): void
     {
         $service = self::getContainer()->get(ElectionUpdateEloService::class);
 
@@ -77,7 +79,8 @@ final class ElectionUpdateEloServiceTest extends KernelTestCase
         );
     }
 
-    public function testVoteBis(): void
+    #[Test]
+    public function voteBis(): void
     {
         $service = self::getContainer()->get(ElectionUpdateEloService::class);
 
@@ -139,7 +142,8 @@ final class ElectionUpdateEloServiceTest extends KernelTestCase
         );
     }
 
-    public function testVoteTer(): void
+    #[Test]
+    public function voteTer(): void
     {
         $service = self::getContainer()->get(ElectionUpdateEloService::class);
 
@@ -179,7 +183,8 @@ final class ElectionUpdateEloServiceTest extends KernelTestCase
         );
     }
 
-    public function testVoteAllLosers(): void
+    #[Test]
+    public function voteAllLosers(): void
     {
         $service = self::getContainer()->get(ElectionUpdateEloService::class);
 
@@ -221,7 +226,8 @@ final class ElectionUpdateEloServiceTest extends KernelTestCase
         );
     }
 
-    public function testVoteAllWinners(): void
+    #[Test]
+    public function voteAllWinners(): void
     {
         $service = self::getContainer()->get(ElectionUpdateEloService::class);
 

--- a/tests/src/Integration/Service/GameBundlesAvailabilitiesServiceTest.php
+++ b/tests/src/Integration/Service/GameBundlesAvailabilitiesServiceTest.php
@@ -10,6 +10,7 @@ use App\Service\GameBundlesAvailabilitiesService;
 use App\Tests\Common\Traits\CounterTrait\CountGameBundleAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -27,7 +28,8 @@ final class GameBundlesAvailabilitiesServiceTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetFromPokemon(): void
+    #[Test]
+    public function getFromPokemon(): void
     {
         $service = self::getContainer()->get(GameBundlesAvailabilitiesService::class);
 

--- a/tests/src/Integration/Service/GameBundlesShiniesAvailabilitiesServiceTest.php
+++ b/tests/src/Integration/Service/GameBundlesShiniesAvailabilitiesServiceTest.php
@@ -10,6 +10,7 @@ use App\Service\GameBundlesShiniesAvailabilitiesService;
 use App\Tests\Common\Traits\CounterTrait\CountGameBundleShinyAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -27,7 +28,8 @@ final class GameBundlesShiniesAvailabilitiesServiceTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetFromPokemon(): void
+    #[Test]
+    public function getFromPokemon(): void
     {
         $service = self::getContainer()->get(GameBundlesShiniesAvailabilitiesService::class);
 

--- a/tests/src/Integration/Service/GamesAvailabilitiesServiceTest.php
+++ b/tests/src/Integration/Service/GamesAvailabilitiesServiceTest.php
@@ -10,6 +10,7 @@ use App\Service\GamesAvailabilitiesService;
 use App\Tests\Common\Traits\CounterTrait\CountGameBundleAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -27,7 +28,8 @@ final class GamesAvailabilitiesServiceTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetFromPokemon(): void
+    #[Test]
+    public function getFromPokemon(): void
     {
         $service = self::getContainer()->get(GamesAvailabilitiesService::class);
 

--- a/tests/src/Integration/Service/GamesShiniesAvailabilitiesServiceTest.php
+++ b/tests/src/Integration/Service/GamesShiniesAvailabilitiesServiceTest.php
@@ -10,6 +10,7 @@ use App\Service\GamesShiniesAvailabilitiesService;
 use App\Tests\Common\Traits\CounterTrait\CountGameBundleAvailabilityTrait;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -27,7 +28,8 @@ final class GamesShiniesAvailabilitiesServiceTest extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testGetFromPokemon(): void
+    #[Test]
+    public function getFromPokemon(): void
     {
         $service = self::getContainer()->get(GamesShiniesAvailabilitiesService::class);
 

--- a/tests/src/Integration/Updater/AbstractTestUpdater.php
+++ b/tests/src/Integration/Updater/AbstractTestUpdater.php
@@ -51,7 +51,7 @@ abstract class AbstractTestUpdater extends KernelTestCase
     }
 
     #[Test]
-    public function do(): void
+    public function execute(): void
     {
         $this->assertEquals($this->initialTotalCount, $this->getTableCount());
         $this->assertEquals($this->initialDeletedTotalCount, $this->getTableDeletedAtCount());

--- a/tests/src/Integration/Updater/AbstractTestUpdater.php
+++ b/tests/src/Integration/Updater/AbstractTestUpdater.php
@@ -8,6 +8,7 @@ use App\Exception\InvalidSheetDataException;
 use App\Updater\AbstractUpdater;
 use Doctrine\DBAL\Connection;
 use Hautelook\AliceBundle\PhpUnit\RefreshDatabaseTrait;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 abstract class AbstractTestUpdater extends KernelTestCase
@@ -27,7 +28,8 @@ abstract class AbstractTestUpdater extends KernelTestCase
         self::bootKernel();
     }
 
-    public function testDoEmptySheet(): void
+    #[Test]
+    public function doEmptySheet(): void
     {
         $service = $this->getService();
 
@@ -37,7 +39,8 @@ abstract class AbstractTestUpdater extends KernelTestCase
         $service->execute('empty');
     }
 
-    public function testDoWrongSheet(): void
+    #[Test]
+    public function doWrongSheet(): void
     {
         $service = $this->getService();
 
@@ -47,7 +50,8 @@ abstract class AbstractTestUpdater extends KernelTestCase
         $service->execute('wrong_sheet');
     }
 
-    public function testDo(): void
+    #[Test]
+    public function do(): void
     {
         $this->assertEquals($this->initialTotalCount, $this->getTableCount());
         $this->assertEquals($this->initialDeletedTotalCount, $this->getTableDeletedAtCount());
@@ -60,7 +64,8 @@ abstract class AbstractTestUpdater extends KernelTestCase
         $this->assertEquals($this->mustBeDeletedTotalCount, $this->getTableDeletedAtCount());
     }
 
-    public function testExecuteTwice(): void
+    #[Test]
+    public function executeTwice(): void
     {
         $this->getService()->execute($this->sheetName);
 

--- a/tests/src/Integration/Updater/DexUpdaterTest.php
+++ b/tests/src/Integration/Updater/DexUpdaterTest.php
@@ -8,6 +8,7 @@ use App\Tests\Common\Traits\GetterTrait\GetDexTrait;
 use App\Updater\AbstractUpdater;
 use App\Updater\DexUpdater;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -25,7 +26,8 @@ final class DexUpdaterTest extends AbstractTestUpdater
     protected string $sheetName = 'Dex';
     protected string $tableName = 'dex';
 
-    public function testDexRegion(): void
+    #[Test]
+    public function dexRegion(): void
     {
         $redGreenBlueYellowBefore = $this->getDexFromSlug('redgreenblueyellow');
         $rubySapphireEmeraldBefore = $this->getDexFromSlug('rubysapphireemerald');
@@ -42,7 +44,8 @@ final class DexUpdaterTest extends AbstractTestUpdater
         $this->assertEquals('Hoenn', $rubySapphireEmeraldAfter['region_name']);
     }
 
-    public function testDexIsReleased(): void
+    #[Test]
+    public function dexIsReleased(): void
     {
         $redGreenBlueYellowBefore = $this->getDexFromSlug('redgreenblueyellow');
         $rubySapphireEmeraldBefore = $this->getDexFromSlug('rubysapphireemerald');

--- a/tests/src/Integration/Updater/Forms/AbstractTestFormsUpdater.php
+++ b/tests/src/Integration/Updater/Forms/AbstractTestFormsUpdater.php
@@ -6,10 +6,12 @@ namespace App\Tests\Integration\Updater\Forms;
 
 use App\Exception\InvalidSheetDataException;
 use App\Tests\Integration\Updater\AbstractTestUpdater;
+use PHPUnit\Framework\Attributes\Test;
 
 abstract class AbstractTestFormsUpdater extends AbstractTestUpdater
 {
-    public function testDoEmptyData(): void
+    #[Test]
+    public function doEmptyData(): void
     {
         $service = $this->getService();
 
@@ -19,7 +21,8 @@ abstract class AbstractTestFormsUpdater extends AbstractTestUpdater
         $service->execute('form / empty_data');
     }
 
-    public function testDoZeroData(): void
+    #[Test]
+    public function doZeroData(): void
     {
         $service = $this->getService();
 
@@ -29,7 +32,8 @@ abstract class AbstractTestFormsUpdater extends AbstractTestUpdater
         $service->execute('form / zero_data');
     }
 
-    public function testDoAnotherList(): void
+    #[Test]
+    public function doAnotherList(): void
     {
         $this->assertEquals($this->initialTotalCount, $this->getTableCount());
         $this->assertEquals(0, $this->getTableDeletedAtCount());
@@ -42,7 +46,8 @@ abstract class AbstractTestFormsUpdater extends AbstractTestUpdater
         $this->assertEquals($this->initialTotalCount, $this->getTableDeletedAtCount());
     }
 
-    public function testDoDifferentColumnsOrder(): void
+    #[Test]
+    public function doDifferentColumnsOrder(): void
     {
         $this->assertEquals($this->initialTotalCount, $this->getTableCount());
         $this->assertEquals(0, $this->getTableDeletedAtCount());

--- a/tests/src/Integration/Updater/PokemonsUpdaterTest.php
+++ b/tests/src/Integration/Updater/PokemonsUpdaterTest.php
@@ -10,6 +10,7 @@ use App\Updater\AbstractUpdater;
 use App\Updater\PokemonsUpdater;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @internal
@@ -27,7 +28,8 @@ final class PokemonsUpdaterTest extends AbstractTestUpdater
     protected string $sheetName = 'Pokémons';
     protected string $tableName = 'pokemon';
 
-    public function testImportNewPokemons(): void
+    #[Test]
+    public function importNewPokemons(): void
     {
         $this->assertGreaterThan(0, $this->getPokemonCount());
         $this->assertEquals($this->getPokemonCount(), $this->getPokemonNotDeletedCount());
@@ -79,7 +81,8 @@ final class PokemonsUpdaterTest extends AbstractTestUpdater
         $this->assertEquals('PokéSprite', $megaCharizardXSmallCredit['source']);
     }
 
-    public function testImportExistingPokemons(): void
+    #[Test]
+    public function importExistingPokemons(): void
     {
         $this->assertGreaterThan(0, $this->getPokemonCount());
         $this->assertEquals($this->getPokemonCount(), $this->getPokemonNotDeletedCount());
@@ -131,7 +134,8 @@ final class PokemonsUpdaterTest extends AbstractTestUpdater
         $this->assertNotNull($ivysaurAfter['secondary_type_id']);
     }
 
-    public function testImportNewAndExistingPokemons(): void
+    #[Test]
+    public function importNewAndExistingPokemons(): void
     {
         $this->assertGreaterThan(0, $this->getPokemonCount());
         $this->assertEquals($this->getPokemonCount(), $this->getPokemonNotDeletedCount());
@@ -144,7 +148,8 @@ final class PokemonsUpdaterTest extends AbstractTestUpdater
         $this->assertEquals(17, $this->getPokemonDeletedCount());
     }
 
-    public function testUpdateRegionalFormPokemons(): void
+    #[Test]
+    public function updateRegionalFormPokemons(): void
     {
         $this->assertGreaterThan(0, $this->getPokemonCount());
         $this->assertEquals($this->getPokemonCount(), $this->getPokemonNotDeletedCount());
@@ -163,7 +168,8 @@ final class PokemonsUpdaterTest extends AbstractTestUpdater
         $this->assertNotNull($pokemonAfter['regional_form_id']);
     }
 
-    public function testUpdateTypesPokemons(): void
+    #[Test]
+    public function updateTypesPokemons(): void
     {
         $this->assertGreaterThan(0, $this->getPokemonCount());
         $this->assertEquals($this->getPokemonCount(), $this->getPokemonNotDeletedCount());
@@ -184,7 +190,8 @@ final class PokemonsUpdaterTest extends AbstractTestUpdater
         $this->assertNotNull($pokemonAfter['secondary_type_id']);
     }
 
-    public function testUpdateFamilyLink(): void
+    #[Test]
+    public function updateFamilyLink(): void
     {
         $this->assertNotEmpty($this->getPokemonFromName('Charmander'));
         $this->assertNotEmpty($this->getPokemonFromName('Charmeleon'));
@@ -221,7 +228,8 @@ final class PokemonsUpdaterTest extends AbstractTestUpdater
         $this->assertEquals('rattata', $raticateFemale['family']);
     }
 
-    public function testDifferentColumnsOrderPokemons(): void
+    #[Test]
+    public function differentColumnsOrderPokemons(): void
     {
         $this->assertGreaterThan(0, $this->getPokemonCount());
         $this->assertEquals($this->getPokemonCount(), $this->getPokemonNotDeletedCount());

--- a/tests/src/Unit/Calculator/DexAvailabilitiesCalculatorTest.php
+++ b/tests/src/Unit/Calculator/DexAvailabilitiesCalculatorTest.php
@@ -12,6 +12,7 @@ use App\Repository\DexAvailabilitiesRepository;
 use App\Repository\DexRepository;
 use Doctrine\ORM\Query;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -21,7 +22,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(AbstractCalculator::class)]
 final class DexAvailabilitiesCalculatorTest extends TestCase
 {
-    public function testInit(): void
+    #[Test]
+    public function init(): void
     {
         $dexAvailabilitiesRepository = $this->createMock(DexAvailabilitiesRepository::class);
         $dexAvailabilitiesRepository
@@ -53,7 +55,8 @@ final class DexAvailabilitiesCalculatorTest extends TestCase
         $this->assertSame(0, $service->getStatistic()->count);
     }
 
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $dexAvailabilitiesRepository = $this->createMock(DexAvailabilitiesRepository::class);
         $dexAvailabilitiesRepository
@@ -96,7 +99,8 @@ final class DexAvailabilitiesCalculatorTest extends TestCase
         $this->assertEquals(6, $statistic->count);
     }
 
-    public function testExecuteTwice(): void
+    #[Test]
+    public function executeTwice(): void
     {
         $dexAvailabilitiesRepository = $this->createMock(DexAvailabilitiesRepository::class);
         $dexAvailabilitiesRepository

--- a/tests/src/Unit/Calculator/DexAvailabilityCalculatorTest.php
+++ b/tests/src/Unit/Calculator/DexAvailabilityCalculatorTest.php
@@ -13,6 +13,7 @@ use App\Repository\PokemonsRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,7 +23,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexAvailability::class)]
 final class DexAvailabilityCalculatorTest extends TestCase
 {
-    public function testCalculate(): void
+    #[Test]
+    public function calculate(): void
     {
         $pokemonA = new Pokemon();
         $pokemonB = new Pokemon();
@@ -87,7 +89,8 @@ final class DexAvailabilityCalculatorTest extends TestCase
         $this->assertEquals(3, $count);
     }
 
-    public function testCalculateTwice(): void
+    #[Test]
+    public function calculateTwice(): void
     {
         $pokemonA = new Pokemon();
         $pokemonB = new Pokemon();
@@ -157,7 +160,8 @@ final class DexAvailabilityCalculatorTest extends TestCase
         $this->assertEquals($firstCount, $count);
     }
 
-    public function testCalculateDefaultBatchSizeDoesNotFlushWith99Items(): void
+    #[Test]
+    public function calculateDefaultBatchSizeDoesNotFlushWith99Items(): void
     {
         $dex = new Dex();
         $pokemons = array_fill(0, 99, new Pokemon());
@@ -190,7 +194,8 @@ final class DexAvailabilityCalculatorTest extends TestCase
         $this->assertEquals(99, $calculator->calculate($dex));
     }
 
-    public function testCalculateDefaultBatchSizeFlushesAfter100Items(): void
+    #[Test]
+    public function calculateDefaultBatchSizeFlushesAfter100Items(): void
     {
         $dex = new Dex();
         $pokemons = array_fill(0, 100, new Pokemon());
@@ -228,7 +233,8 @@ final class DexAvailabilityCalculatorTest extends TestCase
         $this->assertEquals(100, $calculator->calculate($dex));
     }
 
-    public function testCalculateFlushesInBatches(): void
+    #[Test]
+    public function calculateFlushesInBatches(): void
     {
         $pokemons = [new Pokemon(), new Pokemon(), new Pokemon(), new Pokemon(), new Pokemon()];
         $dex = new Dex();
@@ -278,7 +284,8 @@ final class DexAvailabilityCalculatorTest extends TestCase
         $this->assertEquals(5, $count);
     }
 
-    public function testCalculateWithoutAvailabilities(): void
+    #[Test]
+    public function calculateWithoutAvailabilities(): void
     {
         $pokemonA = new Pokemon();
         $pokemonB = new Pokemon();

--- a/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorCollectionsTest.php
+++ b/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorCollectionsTest.php
@@ -15,6 +15,7 @@ use App\Service\GamesAvailabilitiesService;
 use App\Service\GamesShiniesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,8 +24,9 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexPokemonAvailabilityCalculator::class)]
 final class DexPokemonAvailabilityCalculatorCollectionsTest extends TestCase
 {
+    #[Test]
     #[DataProvider('providerCalculateIncludingCollectionsValues')]
-    public function testCalculateIncludingCollectionsValues(string $rule): void
+    public function calculateIncludingCollectionsValues(string $rule): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'pikachu';

--- a/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorGameBundlesShiniesTest.php
+++ b/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorGameBundlesShiniesTest.php
@@ -15,6 +15,7 @@ use App\Service\GamesAvailabilitiesService;
 use App\Service\GamesShiniesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,8 +24,9 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexPokemonAvailabilityCalculator::class)]
 final class DexPokemonAvailabilityCalculatorGameBundlesShiniesTest extends TestCase
 {
+    #[Test]
     #[DataProvider('providerCalculateIncludingGameBundlesShiniesValues')]
-    public function testCalculateIncludingGameBundlesShiniesValues(string $rule): void
+    public function calculateIncludingGameBundlesShiniesValues(string $rule): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'pikachu';

--- a/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorGameBundlesTest.php
+++ b/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorGameBundlesTest.php
@@ -15,6 +15,7 @@ use App\Service\GamesAvailabilitiesService;
 use App\Service\GamesShiniesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,8 +24,9 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexPokemonAvailabilityCalculator::class)]
 final class DexPokemonAvailabilityCalculatorGameBundlesTest extends TestCase
 {
+    #[Test]
     #[DataProvider('providerCalculateIncludingGameBundlesValues')]
-    public function testCalculateIncludingGameBundlesValues(string $rule): void
+    public function calculateIncludingGameBundlesValues(string $rule): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'pikachu';

--- a/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorGamesShiniesTest.php
+++ b/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorGamesShiniesTest.php
@@ -15,6 +15,7 @@ use App\Service\GamesAvailabilitiesService;
 use App\Service\GamesShiniesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,8 +24,9 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexPokemonAvailabilityCalculator::class)]
 final class DexPokemonAvailabilityCalculatorGamesShiniesTest extends TestCase
 {
+    #[Test]
     #[DataProvider('providerCalculateIncludingGamesShiniesValues')]
-    public function testCalculateIncludingGamesShiniesValues(string $rule): void
+    public function calculateIncludingGamesShiniesValues(string $rule): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'pikachu';

--- a/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorGamesTest.php
+++ b/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorGamesTest.php
@@ -15,6 +15,7 @@ use App\Service\GamesAvailabilitiesService;
 use App\Service\GamesShiniesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,8 +24,9 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexPokemonAvailabilityCalculator::class)]
 final class DexPokemonAvailabilityCalculatorGamesTest extends TestCase
 {
+    #[Test]
     #[DataProvider('providerCalculateIncludingGamesValues')]
-    public function testCalculateIncludingGamesValues(string $rule): void
+    public function calculateIncludingGamesValues(string $rule): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'pikachu';

--- a/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorPokemonsTest.php
+++ b/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorPokemonsTest.php
@@ -14,6 +14,7 @@ use App\Service\GamesAvailabilitiesService;
 use App\Service\GamesShiniesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -22,8 +23,9 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexPokemonAvailabilityCalculator::class)]
 final class DexPokemonAvailabilityCalculatorPokemonsTest extends TestCase
 {
+    #[Test]
     #[DataProvider('providerCalculateIncludingPokemonsValues')]
-    public function testCalculateIncludingPokemonsValues(string $rule): void
+    public function calculateIncludingPokemonsValues(string $rule): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'pikachu';

--- a/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorTest.php
+++ b/tests/src/Unit/Calculator/DexPokemonAvailabilityCalculatorTest.php
@@ -15,6 +15,7 @@ use App\Service\GameBundlesShiniesAvailabilitiesService;
 use App\Service\GamesAvailabilitiesService;
 use App\Service\GamesShiniesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
@@ -24,7 +25,8 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 #[CoversClass(DexPokemonAvailabilityCalculator::class)]
 final class DexPokemonAvailabilityCalculatorTest extends TestCase
 {
-    public function testResetExpressionLanguageCacheReplacesTheInstance(): void
+    #[Test]
+    public function resetExpressionLanguageCacheReplacesTheInstance(): void
     {
         $calculator = new DexPokemonAvailabilityCalculator(
             $this->createMock(GameBundlesAvailabilitiesService::class),
@@ -47,7 +49,8 @@ final class DexPokemonAvailabilityCalculatorTest extends TestCase
         $this->assertNotSame($before, $after);
     }
 
-    public function testCalculateNotAvailable(): void
+    #[Test]
+    public function calculateNotAvailable(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'douze';
@@ -104,7 +107,8 @@ final class DexPokemonAvailabilityCalculatorTest extends TestCase
         $this->assertInstanceOf(DexAvailability::class, $dexAvailability);
     }
 
-    public function testCalculateWithoutValues(): void
+    #[Test]
+    public function calculateWithoutValues(): void
     {
         $pokemon = new Pokemon();
 
@@ -154,7 +158,8 @@ final class DexPokemonAvailabilityCalculatorTest extends TestCase
         $this->assertInstanceOf(DexAvailability::class, $dexAvailability);
     }
 
-    public function testCalculateWithoutValuesFalse(): void
+    #[Test]
+    public function calculateWithoutValuesFalse(): void
     {
         $pokemon = new Pokemon();
 

--- a/tests/src/Unit/Calculator/GameBundlesAvailabilitiesCalculatorTest.php
+++ b/tests/src/Unit/Calculator/GameBundlesAvailabilitiesCalculatorTest.php
@@ -8,6 +8,7 @@ use App\Calculator\AbstractCalculator;
 use App\Calculator\GameBundlesAvailabilitiesCalculator;
 use App\Repository\GameBundlesAvailabilitiesRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -17,7 +18,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(AbstractCalculator::class)]
 final class GameBundlesAvailabilitiesCalculatorTest extends TestCase
 {
-    public function testInit(): void
+    #[Test]
+    public function init(): void
     {
         $gameBundlesAvailabilitiesRepository = $this->createMock(GameBundlesAvailabilitiesRepository::class);
         $gameBundlesAvailabilitiesRepository
@@ -37,7 +39,8 @@ final class GameBundlesAvailabilitiesCalculatorTest extends TestCase
         $this->assertSame(0, $service->getStatistic()->count);
     }
 
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $gameBundlesAvailabilitiesRepository = $this->createMock(GameBundlesAvailabilitiesRepository::class);
         $gameBundlesAvailabilitiesRepository
@@ -57,7 +60,8 @@ final class GameBundlesAvailabilitiesCalculatorTest extends TestCase
         $this->assertEquals(12, $statistic->count);
     }
 
-    public function testExecuteTwice(): void
+    #[Test]
+    public function executeTwice(): void
     {
         $gameBundlesAvailabilitiesRepository = $this->createMock(GameBundlesAvailabilitiesRepository::class);
         $gameBundlesAvailabilitiesRepository

--- a/tests/src/Unit/Calculator/GameBundlesShiniesAvailabilitiesCalculatorTest.php
+++ b/tests/src/Unit/Calculator/GameBundlesShiniesAvailabilitiesCalculatorTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Calculator;
 use App\Calculator\GameBundlesShiniesAvailabilitiesCalculator;
 use App\Repository\GameBundlesShiniesAvailabilitiesRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameBundlesShiniesAvailabilitiesCalculator::class)]
 final class GameBundlesShiniesAvailabilitiesCalculatorTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $gameBundlesShiniesAvailabilitiesRepository
             = $this->createMock(GameBundlesShiniesAvailabilitiesRepository::class);
@@ -38,7 +40,8 @@ final class GameBundlesShiniesAvailabilitiesCalculatorTest extends TestCase
         $this->assertEquals(12, $statistic->count);
     }
 
-    public function testExecuteTwice(): void
+    #[Test]
+    public function executeTwice(): void
     {
         $gameBundlesShiniesAvailabilitiesRepository = $this->createMock(
             GameBundlesShiniesAvailabilitiesRepository::class

--- a/tests/src/Unit/Calculator/PokemonAvailabilities/GameBundlesCalculatorTest.php
+++ b/tests/src/Unit/Calculator/PokemonAvailabilities/GameBundlesCalculatorTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Calculator\PokemonAvailabilities;
 use App\Calculator\PokemonAvailabilities\GameBundlesCalculator;
 use App\Repository\PokemonAvailabilitiesRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameBundlesCalculator::class)]
 final class GameBundlesCalculatorTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $repository = $this->createMock(PokemonAvailabilitiesRepository::class);
         $repository
@@ -37,7 +39,8 @@ final class GameBundlesCalculatorTest extends TestCase
         $this->assertEquals(12, $statistic->count);
     }
 
-    public function testExecuteTwice(): void
+    #[Test]
+    public function executeTwice(): void
     {
         $repository = $this->createMock(PokemonAvailabilitiesRepository::class);
         $repository

--- a/tests/src/Unit/Calculator/PokemonAvailabilities/GameBundlesShinyCalculatorTest.php
+++ b/tests/src/Unit/Calculator/PokemonAvailabilities/GameBundlesShinyCalculatorTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Calculator\PokemonAvailabilities;
 use App\Calculator\PokemonAvailabilities\GameBundlesShinyCalculator;
 use App\Repository\PokemonAvailabilitiesRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameBundlesShinyCalculator::class)]
 final class GameBundlesShinyCalculatorTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $repository = $this->createMock(PokemonAvailabilitiesRepository::class);
         $repository
@@ -37,7 +39,8 @@ final class GameBundlesShinyCalculatorTest extends TestCase
         $this->assertEquals(12, $statistic->count);
     }
 
-    public function testExecuteTwice(): void
+    #[Test]
+    public function executeTwice(): void
     {
         $repository = $this->createMock(PokemonAvailabilitiesRepository::class);
         $repository

--- a/tests/src/Unit/Command/CalculateDexAvailabilitiesCommandTest.php
+++ b/tests/src/Unit/Command/CalculateDexAvailabilitiesCommandTest.php
@@ -11,6 +11,7 @@ use App\Repository\ActionLogsRepository;
 use App\Service\CalculatorService\DexAvailabilitiesCalculatorService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[CoversClass(CalculateDexAvailabilitiesCommand::class)]
 final class CalculateDexAvailabilitiesCommandTest extends TestCase
 {
-    public function testFailureOnException(): void
+    #[Test]
+    public function failureOnException(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/src/Unit/Command/CalculateGameBundlesAvailabilitiesCommandTest.php
+++ b/tests/src/Unit/Command/CalculateGameBundlesAvailabilitiesCommandTest.php
@@ -11,6 +11,7 @@ use App\Repository\ActionLogsRepository;
 use App\Service\CalculatorService\GameBundlesAvailabilitiesCalculatorService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[CoversClass(CalculateGameBundlesAvailabilitiesCommand::class)]
 final class CalculateGameBundlesAvailabilitiesCommandTest extends TestCase
 {
-    public function testFailureOnException(): void
+    #[Test]
+    public function failureOnException(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/src/Unit/Command/CalculateGameBundlesShiniesAvailabilitiesCommandTest.php
+++ b/tests/src/Unit/Command/CalculateGameBundlesShiniesAvailabilitiesCommandTest.php
@@ -11,6 +11,7 @@ use App\Repository\ActionLogsRepository;
 use App\Service\CalculatorService\GameBundlesShiniesAvailabilitiesCalculatorService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[CoversClass(CalculateGameBundlesShiniesAvailabilitiesCommand::class)]
 final class CalculateGameBundlesShiniesAvailabilitiesCommandTest extends TestCase
 {
-    public function testFailureOnException(): void
+    #[Test]
+    public function failureOnException(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/src/Unit/Command/CalculatePokemonAvailabilitiesCommandTest.php
+++ b/tests/src/Unit/Command/CalculatePokemonAvailabilitiesCommandTest.php
@@ -11,6 +11,7 @@ use App\Repository\ActionLogsRepository;
 use App\Service\CalculatorService\PokemonAvailabilitiesCalculatorService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[CoversClass(CalculatePokemonAvailabilitiesCommand::class)]
 final class CalculatePokemonAvailabilitiesCommandTest extends TestCase
 {
-    public function testFailureOnException(): void
+    #[Test]
+    public function failureOnException(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/src/Unit/Command/UpdateCollectionsAvailabilitiesCommandTest.php
+++ b/tests/src/Unit/Command/UpdateCollectionsAvailabilitiesCommandTest.php
@@ -11,6 +11,7 @@ use App\Repository\ActionLogsRepository;
 use App\Service\UpdaterService\CollectionsAvailabilitiesUpdaterService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[CoversClass(UpdateCollectionsAvailabilitiesCommand::class)]
 final class UpdateCollectionsAvailabilitiesCommandTest extends TestCase
 {
-    public function testFailureOnException(): void
+    #[Test]
+    public function failureOnException(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/src/Unit/Command/UpdateGamesAvailabilitiesCommandTest.php
+++ b/tests/src/Unit/Command/UpdateGamesAvailabilitiesCommandTest.php
@@ -11,6 +11,7 @@ use App\Repository\ActionLogsRepository;
 use App\Service\UpdaterService\GamesAvailabilitiesUpdaterService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[CoversClass(UpdateGamesAvailabilitiesCommand::class)]
 final class UpdateGamesAvailabilitiesCommandTest extends TestCase
 {
-    public function testFailureOnException(): void
+    #[Test]
+    public function failureOnException(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/src/Unit/Command/UpdateGamesCollectionsAndDexCommandTest.php
+++ b/tests/src/Unit/Command/UpdateGamesCollectionsAndDexCommandTest.php
@@ -11,6 +11,7 @@ use App\Repository\ActionLogsRepository;
 use App\Service\UpdaterService\GamesCollectionsAndDexUpdaterService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[CoversClass(UpdateGamesCollectionsAndDexCommand::class)]
 final class UpdateGamesCollectionsAndDexCommandTest extends TestCase
 {
-    public function testFailureOnException(): void
+    #[Test]
+    public function failureOnException(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/src/Unit/Command/UpdateGamesShiniesAvailabilitiesCommandTest.php
+++ b/tests/src/Unit/Command/UpdateGamesShiniesAvailabilitiesCommandTest.php
@@ -11,6 +11,7 @@ use App\Repository\ActionLogsRepository;
 use App\Service\UpdaterService\GamesShiniesAvailabilitiesUpdaterService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[CoversClass(UpdateGamesShiniesAvailabilitiesCommand::class)]
 final class UpdateGamesShiniesAvailabilitiesCommandTest extends TestCase
 {
-    public function testFailureOnException(): void
+    #[Test]
+    public function failureOnException(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/src/Unit/Command/UpdateLabelsCommandTest.php
+++ b/tests/src/Unit/Command/UpdateLabelsCommandTest.php
@@ -11,6 +11,7 @@ use App\Repository\ActionLogsRepository;
 use App\Service\UpdaterService\LabelsUpdaterService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[CoversClass(UpdateLabelsCommand::class)]
 final class UpdateLabelsCommandTest extends TestCase
 {
-    public function testFailureOnException(): void
+    #[Test]
+    public function failureOnException(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/src/Unit/Command/UpdatePokemonsCommandTest.php
+++ b/tests/src/Unit/Command/UpdatePokemonsCommandTest.php
@@ -11,6 +11,7 @@ use App\Repository\ActionLogsRepository;
 use App\Service\UpdaterService\PokemonsUpdaterService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[CoversClass(UpdatePokemonsCommand::class)]
 final class UpdatePokemonsCommandTest extends TestCase
 {
-    public function testFailureOnException(): void
+    #[Test]
+    public function failureOnException(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/src/Unit/Command/UpdateRegionalDexNumbersCommandTest.php
+++ b/tests/src/Unit/Command/UpdateRegionalDexNumbersCommandTest.php
@@ -11,6 +11,7 @@ use App\Repository\ActionLogsRepository;
 use App\Service\UpdaterService\RegionalDexNumbersUpdaterService;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,7 +23,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 #[CoversClass(UpdateRegionalDexNumbersCommand::class)]
 final class UpdateRegionalDexNumbersCommandTest extends TestCase
 {
-    public function testFailureOnException(): void
+    #[Test]
+    public function failureOnException(): void
     {
         $translator = $this->createMock(TranslatorInterface::class);
         $translator

--- a/tests/src/Unit/Controller/Debug/DebugPokemonControllerTest.php
+++ b/tests/src/Unit/Controller/Debug/DebugPokemonControllerTest.php
@@ -12,6 +12,7 @@ use App\Service\GameBundlesShiniesAvailabilitiesService;
 use App\Service\GamesAvailabilitiesService;
 use App\Service\GamesShiniesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,7 +21,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DebugPokemonController::class)]
 final class DebugPokemonControllerTest extends TestCase
 {
-    public function testPokemonCleanCaches(): void
+    #[Test]
+    public function pokemonCleanCaches(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'zaertyuiop';

--- a/tests/src/Unit/DTO/AlbumFilter/AlbumFilterValueTest.php
+++ b/tests/src/Unit/DTO/AlbumFilter/AlbumFilterValueTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO\AlbumFilter;
 
 use App\DTO\AlbumFilter\AlbumFilterValue;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(AlbumFilterValue::class)]
 final class AlbumFilterValueTest extends TestCase
 {
-    public function testConstruct(): void
+    #[Test]
+    public function construct(): void
     {
         $albumFilterValue = new AlbumFilterValue('douze');
 

--- a/tests/src/Unit/DTO/AlbumFilter/AlbumFilterValuesTest.php
+++ b/tests/src/Unit/DTO/AlbumFilter/AlbumFilterValuesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO\AlbumFilter;
 
 use App\DTO\AlbumFilter\AlbumFilterValues;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(AlbumFilterValues::class)]
 final class AlbumFilterValuesTest extends TestCase
 {
-    public function testConstruct(): void
+    #[Test]
+    public function construct(): void
     {
         $albumFilterValues = new AlbumFilterValues(['douze', 'treize', '!quatorze']);
 
@@ -26,7 +28,8 @@ final class AlbumFilterValuesTest extends TestCase
         $this->assertEquals('quatorze', $albumFilterValues->negativeValues[0]->value);
     }
 
-    public function testExtract(): void
+    #[Test]
+    public function extract(): void
     {
         $albumFilterValues = new AlbumFilterValues(['douze', 'treize', '!quatorze']);
 
@@ -36,7 +39,8 @@ final class AlbumFilterValuesTest extends TestCase
         );
     }
 
-    public function testExtractNegatives(): void
+    #[Test]
+    public function extractNegatives(): void
     {
         $albumFilterValues = new AlbumFilterValues(['douze', 'treize', '!quatorze']);
 
@@ -46,7 +50,8 @@ final class AlbumFilterValuesTest extends TestCase
         );
     }
 
-    public function testExtractManyNegatives(): void
+    #[Test]
+    public function extractManyNegatives(): void
     {
         $albumFilterValues = new AlbumFilterValues(['!douze', '!treize', '!quatorze']);
 
@@ -56,35 +61,40 @@ final class AlbumFilterValuesTest extends TestCase
         );
     }
 
-    public function testHasNull(): void
+    #[Test]
+    public function hasNull(): void
     {
         $albumFilterValues = new AlbumFilterValues(['douze', null, 'treize']);
 
         $this->assertTrue($albumFilterValues->hasNull());
     }
 
-    public function testHasNullFirst(): void
+    #[Test]
+    public function hasNullFirst(): void
     {
         $albumFilterValues = new AlbumFilterValues([null, 'douze']);
 
         $this->assertTrue($albumFilterValues->hasNull());
     }
 
-    public function testHasNullLast(): void
+    #[Test]
+    public function hasNullLast(): void
     {
         $albumFilterValues = new AlbumFilterValues(['douze', null]);
 
         $this->assertTrue($albumFilterValues->hasNull());
     }
 
-    public function testHasNullFalse(): void
+    #[Test]
+    public function hasNullFalse(): void
     {
         $albumFilterValues = new AlbumFilterValues(['douze', 'treize']);
 
         $this->assertFalse($albumFilterValues->hasNull());
     }
 
-    public function testHasNullEmpty(): void
+    #[Test]
+    public function hasNullEmpty(): void
     {
         $albumFilterValues = new AlbumFilterValues([]);
 

--- a/tests/src/Unit/DTO/AlbumFilter/AlbumFiltersRequestTest.php
+++ b/tests/src/Unit/DTO/AlbumFilter/AlbumFiltersRequestTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO\AlbumFilter;
 
 use App\DTO\AlbumFilter\AlbumFiltersRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -15,7 +16,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[CoversClass(AlbumFiltersRequest::class)]
 final class AlbumFiltersRequestTest extends TestCase
 {
-    public function testAlbumFiltersFromRequestEmpty(): void
+    #[Test]
+    public function albumFiltersFromRequestEmpty(): void
     {
         $request = new Request([]);
 
@@ -35,7 +37,8 @@ final class AlbumFiltersRequestTest extends TestCase
         $this->assertEmpty($filters->families->values);
     }
 
-    public function testAlbumFiltersFromRequest(): void
+    #[Test]
+    public function albumFiltersFromRequest(): void
     {
         $request = new Request([
             'primary_types' => ['fire', 'water'],

--- a/tests/src/Unit/DTO/AlbumFilter/AlbumFiltersTest.php
+++ b/tests/src/Unit/DTO/AlbumFilter/AlbumFiltersTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\DTO\AlbumFilter;
 use App\DTO\AlbumFilter\AlbumFilters;
 use App\DTO\AlbumFilter\AlbumFilterValues;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -17,7 +18,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 #[CoversClass(AlbumFilters::class)]
 final class AlbumFiltersTest extends TestCase
 {
-    public function testCreateFromArrayEmpty(): void
+    #[Test]
+    public function createFromArrayEmpty(): void
     {
         $filters = AlbumFilters::createFromArray([]);
 
@@ -50,7 +52,8 @@ final class AlbumFiltersTest extends TestCase
         $this->assertEmpty($filters->collectionAvailabilities->negativeValues);
     }
 
-    public function testCreateFromArray(): void
+    #[Test]
+    public function createFromArray(): void
     {
         $filters = AlbumFilters::createFromArray([
             'primary_types' => ['fire', 'water'],
@@ -97,7 +100,8 @@ final class AlbumFiltersTest extends TestCase
         $this->assertEmpty($filters->collectionAvailabilities->negativeValues);
     }
 
-    public function testCreateFromArrayWithNegative(): void
+    #[Test]
+    public function createFromArrayWithNegative(): void
     {
         $filters = AlbumFilters::createFromArray([
             'primary_types' => ['fire', 'water'],
@@ -144,7 +148,8 @@ final class AlbumFiltersTest extends TestCase
         $this->assertCount(1, $filters->collectionAvailabilities->negativeValues);
     }
 
-    public function testNormalizer(): void
+    #[Test]
+    public function normalizer(): void
     {
         $filterValues = AlbumFilters::normalizer(['a', 'b', 'c']);
 
@@ -153,7 +158,8 @@ final class AlbumFiltersTest extends TestCase
         $this->assertFalse($filterValues->hasNull());
     }
 
-    public function testNormalizerWithNullValue(): void
+    #[Test]
+    public function normalizerWithNullValue(): void
     {
         $filterValues = AlbumFilters::normalizer(['a', 'null', 'c']);
 
@@ -162,7 +168,8 @@ final class AlbumFiltersTest extends TestCase
         $this->assertTrue($filterValues->hasNull());
     }
 
-    public function testNormalizerWithEmptyValue(): void
+    #[Test]
+    public function normalizerWithEmptyValue(): void
     {
         $filterValues = AlbumFilters::normalizer(['a', '', 'c']);
 
@@ -171,7 +178,8 @@ final class AlbumFiltersTest extends TestCase
         $this->assertFalse($filterValues->hasNull());
     }
 
-    public function testNormalizerWithEmptyNegativeValue(): void
+    #[Test]
+    public function normalizerWithEmptyNegativeValue(): void
     {
         $filterValues = AlbumFilters::normalizer(['a', '!b', 'c']);
 
@@ -180,7 +188,8 @@ final class AlbumFiltersTest extends TestCase
         $this->assertFalse($filterValues->hasNull());
     }
 
-    public function testCreateWithOptionsResolver(): void
+    #[Test]
+    public function createWithOptionsResolver(): void
     {
         $resolver = new OptionsResolver();
 
@@ -221,7 +230,8 @@ final class AlbumFiltersTest extends TestCase
         $this->assertInstanceOf(AlbumFilterValues::class, $options['collection_availabilities']);
     }
 
-    public function testCreateWithOptionsResolverException(): void
+    #[Test]
+    public function createWithOptionsResolverException(): void
     {
         $resolver = new OptionsResolver();
 

--- a/tests/src/Unit/DTO/AlbumReport/ReportTest.php
+++ b/tests/src/Unit/DTO/AlbumReport/ReportTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\DTO\AlbumReport;
 use App\DTO\AlbumReport\Report;
 use App\DTO\AlbumReport\Statistic;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Report::class)]
 final class ReportTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $report = new Report(
             12,

--- a/tests/src/Unit/DTO/AlbumReport/StatisticTest.php
+++ b/tests/src/Unit/DTO/AlbumReport/StatisticTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO\AlbumReport;
 
 use App\DTO\AlbumReport\Statistic;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Statistic::class)]
 final class StatisticTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $statisticWithCount = new Statistic(
             slug: 'douze',
@@ -44,7 +46,8 @@ final class StatisticTest extends TestCase
         $this->assertEquals(0, $statisticWithoutCount->count);
     }
 
-    public function testIncrement(): void
+    #[Test]
+    public function increment(): void
     {
         $statisticWithCount = new Statistic(
             slug: 'douze',

--- a/tests/src/Unit/DTO/CollectionsAvailabilitiesTest.php
+++ b/tests/src/Unit/DTO/CollectionsAvailabilitiesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\CollectionsAvailabilities;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CollectionsAvailabilities::class)]
 final class CollectionsAvailabilitiesTest extends TestCase
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $object = new CollectionsAvailabilities([
             'a' => true,
@@ -28,7 +30,8 @@ final class CollectionsAvailabilitiesTest extends TestCase
         $this->assertFalse($object->b);
     }
 
-    public function testSet(): void
+    #[Test]
+    public function set(): void
     {
         $this->expectException(\Exception::class);
 
@@ -38,7 +41,8 @@ final class CollectionsAvailabilitiesTest extends TestCase
         $object->c = true;
     }
 
-    public function testIsset(): void
+    #[Test]
+    public function isset(): void
     {
         $object = new CollectionsAvailabilities([
             'a' => true,
@@ -48,7 +52,8 @@ final class CollectionsAvailabilitiesTest extends TestCase
         $this->assertFalse(isset($object->b));
     }
 
-    public function testAll(): void
+    #[Test]
+    public function all(): void
     {
         $object = new CollectionsAvailabilities([
             'a' => true,

--- a/tests/src/Unit/DTO/DataChangeReport/ReportTest.php
+++ b/tests/src/Unit/DTO/DataChangeReport/ReportTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\DTO\DataChangeReport;
 use App\DTO\DataChangeReport\Report;
 use App\DTO\DataChangeReport\Statistic;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,7 +16,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Report::class)]
 final class ReportTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $report = new Report(
             [
@@ -27,7 +29,8 @@ final class ReportTest extends TestCase
         $this->assertCount(2, $report->detail);
     }
 
-    public function testMerge(): void
+    #[Test]
+    public function merge(): void
     {
         $reportA = new Report(
             [
@@ -46,7 +49,8 @@ final class ReportTest extends TestCase
         $this->assertCount(3, $reportA->detail);
     }
 
-    public function testJsonEncore(): void
+    #[Test]
+    public function jsonEncore(): void
     {
         $report = new Report([
             new Statistic('a', 1),

--- a/tests/src/Unit/DTO/DataChangeReport/StatisticTest.php
+++ b/tests/src/Unit/DTO/DataChangeReport/StatisticTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO\DataChangeReport;
 
 use App\DTO\DataChangeReport\Statistic;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Statistic::class)]
 final class StatisticTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $statisticWithCount = new Statistic('douze', 12);
 
@@ -27,7 +29,8 @@ final class StatisticTest extends TestCase
         $this->assertEquals(0, $statisticWithoutCount->count);
     }
 
-    public function testIncrement(): void
+    #[Test]
+    public function increment(): void
     {
         $statisticWithCount = new Statistic('douze', 12);
 
@@ -44,7 +47,8 @@ final class StatisticTest extends TestCase
         $this->assertEquals(1, $statisticWithoutCount->count);
     }
 
-    public function testIncrementBy(): void
+    #[Test]
+    public function incrementBy(): void
     {
         $statistic = new Statistic('douze', 12);
 

--- a/tests/src/Unit/DTO/DexQueryOptionsTest.php
+++ b/tests/src/Unit/DTO/DexQueryOptionsTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 final class DexQueryOptionsTest extends TestCase
 {
     #[Test]
-    public function ok(): void
+    public function everythingOK(): void
     {
         $attributes = new DexQueryOptions([
             'include_unreleased_dex' => false,

--- a/tests/src/Unit/DTO/DexQueryOptionsTest.php
+++ b/tests/src/Unit/DTO/DexQueryOptionsTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\DexQueryOptions;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
@@ -16,7 +17,8 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 #[CoversClass(DexQueryOptions::class)]
 final class DexQueryOptionsTest extends TestCase
 {
-    public function testOk(): void
+    #[Test]
+    public function ok(): void
     {
         $attributes = new DexQueryOptions([
             'include_unreleased_dex' => false,
@@ -27,7 +29,8 @@ final class DexQueryOptionsTest extends TestCase
         $this->assertTrue($attributes->includePremiumDex);
     }
 
-    public function testMissingAllValue(): void
+    #[Test]
+    public function missingAllValue(): void
     {
         $attributes = new DexQueryOptions([]);
 
@@ -35,7 +38,8 @@ final class DexQueryOptionsTest extends TestCase
         $this->assertFalse($attributes->includePremiumDex);
     }
 
-    public function testWrongValueUnreleased(): void
+    #[Test]
+    public function wrongValueUnreleased(): void
     {
         $this->expectException(InvalidOptionsException::class);
         new DexQueryOptions([
@@ -43,7 +47,8 @@ final class DexQueryOptionsTest extends TestCase
         ]);
     }
 
-    public function testWrongValuePremium(): void
+    #[Test]
+    public function wrongValuePremium(): void
     {
         $this->expectException(InvalidOptionsException::class);
         new DexQueryOptions([
@@ -51,7 +56,8 @@ final class DexQueryOptionsTest extends TestCase
         ]);
     }
 
-    public function testAnotherValue(): void
+    #[Test]
+    public function anotherValue(): void
     {
         $this->expectException(UndefinedOptionsException::class);
         new DexQueryOptions(['includeUnreleasedDex' => true, 'is_on_home' => false]);

--- a/tests/src/Unit/DTO/ElectionPokemonsListTest.php
+++ b/tests/src/Unit/DTO/ElectionPokemonsListTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\ElectionPokemonsList;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ElectionPokemonsList::class)]
 final class ElectionPokemonsListTest extends TestCase
 {
-    public function testOk(): void
+    #[Test]
+    public function ok(): void
     {
         $attributes = new ElectionPokemonsList(
             'pick',

--- a/tests/src/Unit/DTO/ElectionPokemonsListTest.php
+++ b/tests/src/Unit/DTO/ElectionPokemonsListTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 final class ElectionPokemonsListTest extends TestCase
 {
     #[Test]
-    public function ok(): void
+    public function everythingOK(): void
     {
         $attributes = new ElectionPokemonsList(
             'pick',

--- a/tests/src/Unit/DTO/ElectionReport/ReportTest.php
+++ b/tests/src/Unit/DTO/ElectionReport/ReportTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO\ElectionReport;
 
 use App\DTO\ElectionReport\Report;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Report::class)]
 final class ReportTest extends TestCase
 {
-    public function testConstructor(): void
+    #[Test]
+    public function constructor(): void
     {
         $top = [
             ['pokemon_slug' => 'pikachu'],

--- a/tests/src/Unit/DTO/ElectionReportQueryOptionsTest.php
+++ b/tests/src/Unit/DTO/ElectionReportQueryOptionsTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\ElectionReportQueryOptions;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
@@ -16,7 +17,8 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 #[CoversClass(ElectionReportQueryOptions::class)]
 final class ElectionReportQueryOptionsTest extends TestCase
 {
-    public function testDefaults(): void
+    #[Test]
+    public function defaults(): void
     {
         $options = new ElectionReportQueryOptions();
 
@@ -24,7 +26,8 @@ final class ElectionReportQueryOptionsTest extends TestCase
         $this->assertSame(5, $options->count);
     }
 
-    public function testExplicitValues(): void
+    #[Test]
+    public function explicitValues(): void
     {
         $options = new ElectionReportQueryOptions([
             'election_slug' => 'favorite',
@@ -35,21 +38,24 @@ final class ElectionReportQueryOptionsTest extends TestCase
         $this->assertSame(10, $options->count);
     }
 
-    public function testInvalidElectionSlugType(): void
+    #[Test]
+    public function invalidElectionSlugType(): void
     {
         $this->expectException(InvalidOptionsException::class);
 
         new ElectionReportQueryOptions(['election_slug' => 12]);
     }
 
-    public function testUnknownOption(): void
+    #[Test]
+    public function unknownOption(): void
     {
         $this->expectException(UndefinedOptionsException::class);
 
         new ElectionReportQueryOptions(['unknown' => 'value']);
     }
 
-    public function testInvalidCountType(): void
+    #[Test]
+    public function invalidCountType(): void
     {
         $this->expectException(InvalidOptionsException::class);
 

--- a/tests/src/Unit/DTO/ElectionVoteResultTest.php
+++ b/tests/src/Unit/DTO/ElectionVoteResultTest.php
@@ -8,6 +8,7 @@ use App\DTO\ElectionVote;
 use App\DTO\ElectionVoteResult;
 use App\DTO\PokemonElo;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ElectionVoteResult::class)]
 final class ElectionVoteResultTest extends TestCase
 {
-    public function testOk(): void
+    #[Test]
+    public function ok(): void
     {
         $electionVote = new ElectionVote([
             'trainer' => ['external_id' => '67865468'],

--- a/tests/src/Unit/DTO/ElectionVoteResultTest.php
+++ b/tests/src/Unit/DTO/ElectionVoteResultTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 final class ElectionVoteResultTest extends TestCase
 {
     #[Test]
-    public function ok(): void
+    public function everythingOK(): void
     {
         $electionVote = new ElectionVote([
             'trainer' => ['external_id' => '67865468'],

--- a/tests/src/Unit/DTO/ElectionVoteTest.php
+++ b/tests/src/Unit/DTO/ElectionVoteTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 final class ElectionVoteTest extends TestCase
 {
     #[Test]
-    public function ok(): void
+    public function everythingOK(): void
     {
         $attributes = new ElectionVote([
             'trainer' => ['external_id' => '67865468'],

--- a/tests/src/Unit/DTO/ElectionVoteTest.php
+++ b/tests/src/Unit/DTO/ElectionVoteTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\ElectionVote;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
@@ -16,7 +17,8 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 #[CoversClass(ElectionVote::class)]
 final class ElectionVoteTest extends TestCase
 {
-    public function testOk(): void
+    #[Test]
+    public function ok(): void
     {
         $attributes = new ElectionVote([
             'trainer' => ['external_id' => '67865468'],
@@ -33,7 +35,8 @@ final class ElectionVoteTest extends TestCase
         $this->assertSame(['pichu', 'raichu'], $attributes->losersSlugs);
     }
 
-    public function testMissingElectionSlug(): void
+    #[Test]
+    public function missingElectionSlug(): void
     {
         $attributes = new ElectionVote([
             'trainer' => ['external_id' => '67865468'],
@@ -49,7 +52,8 @@ final class ElectionVoteTest extends TestCase
         $this->assertSame(['pichu', 'raichu'], $attributes->losersSlugs);
     }
 
-    public function testWrongTypeForTrainer(): void
+    #[Test]
+    public function wrongTypeForTrainer(): void
     {
         $this->expectException(InvalidOptionsException::class);
 
@@ -61,7 +65,8 @@ final class ElectionVoteTest extends TestCase
         ]);
     }
 
-    public function testWrongTypeForTrainerExternalId(): void
+    #[Test]
+    public function wrongTypeForTrainerExternalId(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -73,7 +78,8 @@ final class ElectionVoteTest extends TestCase
         ]);
     }
 
-    public function testWrongValueForElectionSlug(): void
+    #[Test]
+    public function wrongValueForElectionSlug(): void
     {
         $this->expectException(InvalidOptionsException::class);
 
@@ -86,7 +92,8 @@ final class ElectionVoteTest extends TestCase
         ]);
     }
 
-    public function testWrongValueForDexSlug(): void
+    #[Test]
+    public function wrongValueForDexSlug(): void
     {
         $this->expectException(InvalidOptionsException::class);
 
@@ -99,7 +106,8 @@ final class ElectionVoteTest extends TestCase
         ]);
     }
 
-    public function testWrongValueForWinnersSlugs(): void
+    #[Test]
+    public function wrongValueForWinnersSlugs(): void
     {
         $this->expectException(InvalidOptionsException::class);
         new ElectionVote([
@@ -110,7 +118,8 @@ final class ElectionVoteTest extends TestCase
         ]);
     }
 
-    public function testWrongValueForLosersSlugs(): void
+    #[Test]
+    public function wrongValueForLosersSlugs(): void
     {
         $this->expectException(InvalidOptionsException::class);
         new ElectionVote([
@@ -121,7 +130,8 @@ final class ElectionVoteTest extends TestCase
         ]);
     }
 
-    public function testAnotherValue(): void
+    #[Test]
+    public function anotherValue(): void
     {
         $this->expectException(UndefinedOptionsException::class);
         new ElectionVote([

--- a/tests/src/Unit/DTO/GameBundlesAvailabilitiesTest.php
+++ b/tests/src/Unit/DTO/GameBundlesAvailabilitiesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\GameBundlesAvailabilities;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameBundlesAvailabilities::class)]
 final class GameBundlesAvailabilitiesTest extends TestCase
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $object = new GameBundlesAvailabilities([
             'a' => true,
@@ -28,7 +30,8 @@ final class GameBundlesAvailabilitiesTest extends TestCase
         $this->assertFalse($object->b);
     }
 
-    public function testSet(): void
+    #[Test]
+    public function set(): void
     {
         $this->expectException(\Exception::class);
 
@@ -38,7 +41,8 @@ final class GameBundlesAvailabilitiesTest extends TestCase
         $object->c = true;
     }
 
-    public function testIsset(): void
+    #[Test]
+    public function isset(): void
     {
         $object = new GameBundlesAvailabilities([
             'a' => true,
@@ -48,7 +52,8 @@ final class GameBundlesAvailabilitiesTest extends TestCase
         $this->assertFalse(isset($object->b));
     }
 
-    public function testAll(): void
+    #[Test]
+    public function all(): void
     {
         $object = new GameBundlesAvailabilities([
             'a' => true,

--- a/tests/src/Unit/DTO/GameBundlesShiniesAvailabilitiesTest.php
+++ b/tests/src/Unit/DTO/GameBundlesShiniesAvailabilitiesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\GameBundlesShiniesAvailabilities;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameBundlesShiniesAvailabilities::class)]
 final class GameBundlesShiniesAvailabilitiesTest extends TestCase
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $object = new GameBundlesShiniesAvailabilities([
             'a' => true,
@@ -28,7 +30,8 @@ final class GameBundlesShiniesAvailabilitiesTest extends TestCase
         $this->assertFalse($object->b);
     }
 
-    public function testSet(): void
+    #[Test]
+    public function set(): void
     {
         $this->expectException(\Exception::class);
 
@@ -38,7 +41,8 @@ final class GameBundlesShiniesAvailabilitiesTest extends TestCase
         $object->c = true;
     }
 
-    public function testIsset(): void
+    #[Test]
+    public function isset(): void
     {
         $object = new GameBundlesShiniesAvailabilities([
             'a' => true,
@@ -48,7 +52,8 @@ final class GameBundlesShiniesAvailabilitiesTest extends TestCase
         $this->assertFalse(isset($object->b));
     }
 
-    public function testAll(): void
+    #[Test]
+    public function all(): void
     {
         $object = new GameBundlesShiniesAvailabilities([
             'a' => true,

--- a/tests/src/Unit/DTO/GamesAvailabilitiesTest.php
+++ b/tests/src/Unit/DTO/GamesAvailabilitiesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\GamesAvailabilities;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GamesAvailabilities::class)]
 final class GamesAvailabilitiesTest extends TestCase
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $object = new GamesAvailabilities([
             'a' => true,
@@ -28,7 +30,8 @@ final class GamesAvailabilitiesTest extends TestCase
         $this->assertFalse($object->b);
     }
 
-    public function testSet(): void
+    #[Test]
+    public function set(): void
     {
         $this->expectException(\Exception::class);
 
@@ -38,7 +41,8 @@ final class GamesAvailabilitiesTest extends TestCase
         $object->c = true;
     }
 
-    public function testIsset(): void
+    #[Test]
+    public function isset(): void
     {
         $object = new GamesAvailabilities([
             'a' => true,
@@ -48,7 +52,8 @@ final class GamesAvailabilitiesTest extends TestCase
         $this->assertFalse(isset($object->b));
     }
 
-    public function testAll(): void
+    #[Test]
+    public function all(): void
     {
         $object = new GamesAvailabilities([
             'a' => true,

--- a/tests/src/Unit/DTO/GamesShiniesAvailabilitiesTest.php
+++ b/tests/src/Unit/DTO/GamesShiniesAvailabilitiesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\GamesShiniesAvailabilities;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GamesShiniesAvailabilities::class)]
 final class GamesShiniesAvailabilitiesTest extends TestCase
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $object = new GamesShiniesAvailabilities([
             'a' => true,
@@ -28,7 +30,8 @@ final class GamesShiniesAvailabilitiesTest extends TestCase
         $this->assertFalse($object->b);
     }
 
-    public function testSet(): void
+    #[Test]
+    public function set(): void
     {
         $this->expectException(\Exception::class);
 
@@ -38,7 +41,8 @@ final class GamesShiniesAvailabilitiesTest extends TestCase
         $object->c = true;
     }
 
-    public function testIsset(): void
+    #[Test]
+    public function isset(): void
     {
         $object = new GamesShiniesAvailabilities([
             'a' => true,
@@ -48,7 +52,8 @@ final class GamesShiniesAvailabilitiesTest extends TestCase
         $this->assertFalse(isset($object->b));
     }
 
-    public function testAll(): void
+    #[Test]
+    public function all(): void
     {
         $object = new GamesShiniesAvailabilities([
             'a' => true,

--- a/tests/src/Unit/DTO/PokemonEloTest.php
+++ b/tests/src/Unit/DTO/PokemonEloTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 final class PokemonEloTest extends TestCase
 {
     #[Test]
-    public function ok(): void
+    public function everythingOK(): void
     {
         $attributes = new PokemonElo('pikachu', 12);
 

--- a/tests/src/Unit/DTO/PokemonEloTest.php
+++ b/tests/src/Unit/DTO/PokemonEloTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\PokemonElo;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokemonElo::class)]
 final class PokemonEloTest extends TestCase
 {
-    public function testOk(): void
+    #[Test]
+    public function ok(): void
     {
         $attributes = new PokemonElo('pikachu', 12);
 

--- a/tests/src/Unit/DTO/TrainerDexAttributesTest.php
+++ b/tests/src/Unit/DTO/TrainerDexAttributesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\TrainerDexAttributes;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
@@ -16,21 +17,24 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 #[CoversClass(TrainerDexAttributes::class)]
 final class TrainerDexAttributesTest extends TestCase
 {
-    public function testOk(): void
+    #[Test]
+    public function ok(): void
     {
         $attributes = new TrainerDexAttributes(['is_private' => false, 'is_on_home' => false]);
 
         $this->assertFalse($attributes->isPrivate);
     }
 
-    public function testMissingOneValue(): void
+    #[Test]
+    public function missingOneValue(): void
     {
         $attributes = new TrainerDexAttributes(['is_on_home' => true]);
 
         $this->assertFalse($attributes->isPrivate);
     }
 
-    public function testMissingAllValue(): void
+    #[Test]
+    public function missingAllValue(): void
     {
         $attributes = new TrainerDexAttributes([]);
 
@@ -38,19 +42,22 @@ final class TrainerDexAttributesTest extends TestCase
         $this->assertFalse($attributes->isOnHome);
     }
 
-    public function testWrongValue(): void
+    #[Test]
+    public function wrongValue(): void
     {
         $this->expectException(InvalidOptionsException::class);
         new TrainerDexAttributes(['is_private' => 'yes', 'is_on_home' => false]);
     }
 
-    public function testWrongValueBis(): void
+    #[Test]
+    public function wrongValueBis(): void
     {
         $this->expectException(InvalidOptionsException::class);
         new TrainerDexAttributes(['is_private' => true, 'is_on_home' => 'no']);
     }
 
-    public function testAnotherValue(): void
+    #[Test]
+    public function anotherValue(): void
     {
         $this->expectException(UndefinedOptionsException::class);
         new TrainerDexAttributes(['isPrivate' => true, 'is_on_home' => false]);

--- a/tests/src/Unit/DTO/TrainerDexAttributesTest.php
+++ b/tests/src/Unit/DTO/TrainerDexAttributesTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 final class TrainerDexAttributesTest extends TestCase
 {
     #[Test]
-    public function ok(): void
+    public function everythingOK(): void
     {
         $attributes = new TrainerDexAttributes(['is_private' => false, 'is_on_home' => false]);
 

--- a/tests/src/Unit/DTO/TrainerPokemonEloListQueryOptionsTest.php
+++ b/tests/src/Unit/DTO/TrainerPokemonEloListQueryOptionsTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\DTO;
 
 use App\DTO\TrainerPokemonEloListQueryOptions;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
@@ -17,7 +18,8 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 #[CoversClass(TrainerPokemonEloListQueryOptions::class)]
 final class TrainerPokemonEloListQueryOptionsTest extends TestCase
 {
-    public function testOk(): void
+    #[Test]
+    public function ok(): void
     {
         $attributes = new TrainerPokemonEloListQueryOptions([
             'trainer_external_id' => '67865468',
@@ -32,7 +34,8 @@ final class TrainerPokemonEloListQueryOptionsTest extends TestCase
         $this->assertSame(12, $attributes->count);
     }
 
-    public function testWithAlbumFilters(): void
+    #[Test]
+    public function withAlbumFilters(): void
     {
         $attributes = new TrainerPokemonEloListQueryOptions([
             'trainer_external_id' => '67865468',
@@ -60,7 +63,8 @@ final class TrainerPokemonEloListQueryOptionsTest extends TestCase
         $this->assertSame(12, $attributes->count);
     }
 
-    public function testMissingTrainerExternalId(): void
+    #[Test]
+    public function missingTrainerExternalId(): void
     {
         $this->expectException(MissingOptionsException::class);
         new TrainerPokemonEloListQueryOptions([
@@ -70,7 +74,8 @@ final class TrainerPokemonEloListQueryOptionsTest extends TestCase
         ]);
     }
 
-    public function testMissingDexSlug(): void
+    #[Test]
+    public function missingDexSlug(): void
     {
         $this->expectException(MissingOptionsException::class);
         new TrainerPokemonEloListQueryOptions([
@@ -80,7 +85,8 @@ final class TrainerPokemonEloListQueryOptionsTest extends TestCase
         ]);
     }
 
-    public function testMissingElectionSlug(): void
+    #[Test]
+    public function missingElectionSlug(): void
     {
         $attributes = new TrainerPokemonEloListQueryOptions([
             'trainer_external_id' => '67865468',
@@ -94,7 +100,8 @@ final class TrainerPokemonEloListQueryOptionsTest extends TestCase
         $this->assertSame(12, $attributes->count);
     }
 
-    public function testMissingCount(): void
+    #[Test]
+    public function missingCount(): void
     {
         $this->expectException(MissingOptionsException::class);
         new TrainerPokemonEloListQueryOptions([
@@ -104,7 +111,8 @@ final class TrainerPokemonEloListQueryOptionsTest extends TestCase
         ]);
     }
 
-    public function testWrongValueForTrainerExternalId(): void
+    #[Test]
+    public function wrongValueForTrainerExternalId(): void
     {
         $this->expectException(InvalidOptionsException::class);
         new TrainerPokemonEloListQueryOptions([
@@ -115,7 +123,8 @@ final class TrainerPokemonEloListQueryOptionsTest extends TestCase
         ]);
     }
 
-    public function testWrongValueForDexSlug(): void
+    #[Test]
+    public function wrongValueForDexSlug(): void
     {
         $this->expectException(InvalidOptionsException::class);
         new TrainerPokemonEloListQueryOptions([
@@ -126,7 +135,8 @@ final class TrainerPokemonEloListQueryOptionsTest extends TestCase
         ]);
     }
 
-    public function testWrongValueForElectionSlug(): void
+    #[Test]
+    public function wrongValueForElectionSlug(): void
     {
         $this->expectException(InvalidOptionsException::class);
         new TrainerPokemonEloListQueryOptions([
@@ -137,7 +147,8 @@ final class TrainerPokemonEloListQueryOptionsTest extends TestCase
         ]);
     }
 
-    public function testWrongValueForCount(): void
+    #[Test]
+    public function wrongValueForCount(): void
     {
         $this->expectException(InvalidOptionsException::class);
 
@@ -154,7 +165,8 @@ final class TrainerPokemonEloListQueryOptionsTest extends TestCase
         ]);
     }
 
-    public function testCountNormalizer(): void
+    #[Test]
+    public function countNormalizer(): void
     {
         $attributes = new TrainerPokemonEloListQueryOptions([
             'trainer_external_id' => '67865468',
@@ -169,7 +181,8 @@ final class TrainerPokemonEloListQueryOptionsTest extends TestCase
         $this->assertSame(12, $attributes->count);
     }
 
-    public function testAnotherValue(): void
+    #[Test]
+    public function anotherValue(): void
     {
         $this->expectException(UndefinedOptionsException::class);
         new TrainerPokemonEloListQueryOptions([

--- a/tests/src/Unit/DTO/TrainerPokemonEloListQueryOptionsTest.php
+++ b/tests/src/Unit/DTO/TrainerPokemonEloListQueryOptionsTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 final class TrainerPokemonEloListQueryOptionsTest extends TestCase
 {
     #[Test]
-    public function ok(): void
+    public function everythingOK(): void
     {
         $attributes = new TrainerPokemonEloListQueryOptions([
             'trainer_external_id' => '67865468',

--- a/tests/src/Unit/Entity/ActionLogTest.php
+++ b/tests/src/Unit/Entity/ActionLogTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\ActionLog;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(ActionLog::class)]
 final class ActionLogTest extends TestCase
 {
-    public function testConstructorAndGetters(): void
+    #[Test]
+    public function constructorAndGetters(): void
     {
         $entity = new ActionLog('alpha');
 
         $this->assertSame('alpha', $entity->getType());
     }
 
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new ActionLog('alpha');
 

--- a/tests/src/Unit/Entity/CatchStateTest.php
+++ b/tests/src/Unit/Entity/CatchStateTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\CatchState;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CatchState::class)]
 final class CatchStateTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new CatchState();
 
         $this->assertNull($entity->getIdentifier());
     }
 
-    public function testConvertToString(): void
+    #[Test]
+    public function convertToString(): void
     {
         $entity = new CatchState();
         $entity->name = 'Douze';

--- a/tests/src/Unit/Entity/CategoryFormTest.php
+++ b/tests/src/Unit/Entity/CategoryFormTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\CategoryForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CategoryForm::class)]
 final class CategoryFormTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new CategoryForm();
 
         $this->assertNull($entity->getIdentifier());
     }
 
-    public function testConvertToString(): void
+    #[Test]
+    public function convertToString(): void
     {
         $entity = new CategoryForm();
         $entity->name = 'Douze';

--- a/tests/src/Unit/Entity/CollectionAvailabilityTest.php
+++ b/tests/src/Unit/Entity/CollectionAvailabilityTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\CollectionAvailability;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CollectionAvailability::class)]
 final class CollectionAvailabilityTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new CollectionAvailability();
 

--- a/tests/src/Unit/Entity/CollectionTest.php
+++ b/tests/src/Unit/Entity/CollectionTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\Collection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Collection::class)]
 final class CollectionTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new Collection();
 
         $this->assertNull($entity->getIdentifier());
     }
 
-    public function testConvertToString(): void
+    #[Test]
+    public function convertToString(): void
     {
         $entity = new Collection();
         $entity->name = 'Douze';

--- a/tests/src/Unit/Entity/DexAvailabilityTest.php
+++ b/tests/src/Unit/Entity/DexAvailabilityTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\DexAvailability;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexAvailability::class)]
 final class DexAvailabilityTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new DexAvailability();
 

--- a/tests/src/Unit/Entity/DexTest.php
+++ b/tests/src/Unit/Entity/DexTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\Dex;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Dex::class)]
 final class DexTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new Dex();
 
         $this->assertNull($entity->getIdentifier());
     }
 
-    public function testConvertToString(): void
+    #[Test]
+    public function convertToString(): void
     {
         $entity = new Dex();
         $entity->name = 'Douze';

--- a/tests/src/Unit/Entity/GameAvailabilityTest.php
+++ b/tests/src/Unit/Entity/GameAvailabilityTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\GameAvailability;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameAvailability::class)]
 final class GameAvailabilityTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new GameAvailability();
 

--- a/tests/src/Unit/Entity/GameBundleAvailabilityTest.php
+++ b/tests/src/Unit/Entity/GameBundleAvailabilityTest.php
@@ -8,6 +8,7 @@ use App\Entity\GameBundle;
 use App\Entity\GameBundleAvailability;
 use App\Entity\Pokemon;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameBundleAvailability::class)]
 final class GameBundleAvailabilityTest extends TestCase
 {
-    public function testCreateAvailable(): void
+    #[Test]
+    public function createAvailable(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'Douze';
@@ -35,7 +37,8 @@ final class GameBundleAvailabilityTest extends TestCase
         $this->assertTrue($gameBundleAvailability->isAvailable);
     }
 
-    public function testCreateUnavailable(): void
+    #[Test]
+    public function createUnavailable(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'Douze';
@@ -54,7 +57,8 @@ final class GameBundleAvailabilityTest extends TestCase
         $this->assertFalse($gameBundleAvailability->isAvailable);
     }
 
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'Douze';

--- a/tests/src/Unit/Entity/GameBundleShinyAvailabilityTest.php
+++ b/tests/src/Unit/Entity/GameBundleShinyAvailabilityTest.php
@@ -8,6 +8,7 @@ use App\Entity\GameBundle;
 use App\Entity\GameBundleShinyAvailability;
 use App\Entity\Pokemon;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameBundleShinyAvailability::class)]
 final class GameBundleShinyAvailabilityTest extends TestCase
 {
-    public function testCreateAvailable(): void
+    #[Test]
+    public function createAvailable(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'Douze';
@@ -35,7 +37,8 @@ final class GameBundleShinyAvailabilityTest extends TestCase
         $this->assertTrue($gameBundleShinyAvailability->isAvailable);
     }
 
-    public function testCreateUnavailable(): void
+    #[Test]
+    public function createUnavailable(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'Douze';
@@ -54,7 +57,8 @@ final class GameBundleShinyAvailabilityTest extends TestCase
         $this->assertFalse($gameBundleShinyAvailability->isAvailable);
     }
 
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'Douze';

--- a/tests/src/Unit/Entity/GameBundleTest.php
+++ b/tests/src/Unit/Entity/GameBundleTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\GameBundle;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameBundle::class)]
 final class GameBundleTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new GameBundle();
 
         $this->assertNull($entity->getIdentifier());
     }
 
-    public function testConvertToString(): void
+    #[Test]
+    public function convertToString(): void
     {
         $entity = new GameBundle();
         $entity->name = 'Douze';

--- a/tests/src/Unit/Entity/GameGenerationTest.php
+++ b/tests/src/Unit/Entity/GameGenerationTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\GameGeneration;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameGeneration::class)]
 final class GameGenerationTest extends TestCase
 {
-    public function testGetNumber(): void
+    #[Test]
+    public function getNumber(): void
     {
         $generation = new GameGeneration();
         $generation->name = '12';
@@ -22,14 +24,16 @@ final class GameGenerationTest extends TestCase
         $this->assertSame(12, $generation->getNumber());
     }
 
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $generation = new GameGeneration();
 
         $this->assertNull($generation->getIdentifier());
     }
 
-    public function testGetIdentifier(): void
+    #[Test]
+    public function getIdentifier(): void
     {
         $generation = new GameGeneration();
         $generation->name = 'Douze';

--- a/tests/src/Unit/Entity/GameShinyAvailabilityTest.php
+++ b/tests/src/Unit/Entity/GameShinyAvailabilityTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\GameShinyAvailability;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GameShinyAvailability::class)]
 final class GameShinyAvailabilityTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new GameShinyAvailability();
 

--- a/tests/src/Unit/Entity/GameTest.php
+++ b/tests/src/Unit/Entity/GameTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\Game;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Game::class)]
 final class GameTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new Game();
 
         $this->assertNull($entity->getIdentifier());
     }
 
-    public function testConvertToString(): void
+    #[Test]
+    public function convertToString(): void
     {
         $entity = new Game();
         $entity->name = 'Douze';

--- a/tests/src/Unit/Entity/PokedexTest.php
+++ b/tests/src/Unit/Entity/PokedexTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\Pokedex;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Pokedex::class)]
 final class PokedexTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new Pokedex();
 

--- a/tests/src/Unit/Entity/PokemonAvailabilitiesTest.php
+++ b/tests/src/Unit/Entity/PokemonAvailabilitiesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\PokemonAvailabilities;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokemonAvailabilities::class)]
 final class PokemonAvailabilitiesTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new PokemonAvailabilities();
 

--- a/tests/src/Unit/Entity/PokemonTest.php
+++ b/tests/src/Unit/Entity/PokemonTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\Pokemon;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Pokemon::class)]
 final class PokemonTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new Pokemon();
 
         $this->assertNull($entity->getIdentifier());
     }
 
-    public function testConvertToString(): void
+    #[Test]
+    public function convertToString(): void
     {
         $entity = new Pokemon();
         $entity->name = 'Douze';

--- a/tests/src/Unit/Entity/RegionTest.php
+++ b/tests/src/Unit/Entity/RegionTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\Region;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Region::class)]
 final class RegionTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new Region();
 
         $this->assertNull($entity->getIdentifier());
     }
 
-    public function testConvertToString(): void
+    #[Test]
+    public function convertToString(): void
     {
         $entity = new Region();
         $entity->name = 'Douze';

--- a/tests/src/Unit/Entity/RegionalDexNumberTest.php
+++ b/tests/src/Unit/Entity/RegionalDexNumberTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\RegionalDexNumber;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(RegionalDexNumber::class)]
 final class RegionalDexNumberTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new RegionalDexNumber();
 

--- a/tests/src/Unit/Entity/SpecialFormTest.php
+++ b/tests/src/Unit/Entity/SpecialFormTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\SpecialForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(SpecialForm::class)]
 final class SpecialFormTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new SpecialForm();
 
         $this->assertNull($entity->getIdentifier());
     }
 
-    public function testConvertToString(): void
+    #[Test]
+    public function convertToString(): void
     {
         $entity = new SpecialForm();
         $entity->name = 'Douze';

--- a/tests/src/Unit/Entity/TrainerDexLinkTest.php
+++ b/tests/src/Unit/Entity/TrainerDexLinkTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\TrainerDexLink;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TrainerDexLink::class)]
 final class TrainerDexLinkTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new TrainerDexLink();
 

--- a/tests/src/Unit/Entity/TrainerDexTest.php
+++ b/tests/src/Unit/Entity/TrainerDexTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\TrainerDex;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TrainerDex::class)]
 final class TrainerDexTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new TrainerDex();
 

--- a/tests/src/Unit/Entity/TrainerPokemonEloTest.php
+++ b/tests/src/Unit/Entity/TrainerPokemonEloTest.php
@@ -8,6 +8,7 @@ use App\Entity\Dex;
 use App\Entity\Pokemon;
 use App\Entity\TrainerPokemonElo;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TrainerPokemonElo::class)]
 final class TrainerPokemonEloTest extends TestCase
 {
-    public function testConstructorAndGetters(): void
+    #[Test]
+    public function constructorAndGetters(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'Douze';
@@ -33,7 +35,8 @@ final class TrainerPokemonEloTest extends TestCase
         $this->assertSame('', $entity->getElectionSlug());
     }
 
-    public function testConstructorAndGettersWithElectionSlug(): void
+    #[Test]
+    public function constructorAndGettersWithElectionSlug(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'Douze';

--- a/tests/src/Unit/Entity/Traits/SoftDeleteableTest.php
+++ b/tests/src/Unit/Entity/Traits/SoftDeleteableTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Entity\Traits;
 use App\Entity\Pokemon;
 use App\Entity\Traits\SoftDeleteable;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,14 +16,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversTrait(SoftDeleteable::class)]
 final class SoftDeleteableTest extends TestCase
 {
-    public function testGetDeletedAtReturnsNullByDefault(): void
+    #[Test]
+    public function getDeletedAtReturnsNullByDefault(): void
     {
         $entity = new Pokemon();
 
         $this->assertNull($entity->getDeletedAt());
     }
 
-    public function testGetDeletedAtReflectsDeletedAtProperty(): void
+    #[Test]
+    public function getDeletedAtReflectsDeletedAtProperty(): void
     {
         $entity = new Pokemon();
         $date = new \DateTime('2026-01-01');

--- a/tests/src/Unit/Entity/TypeTest.php
+++ b/tests/src/Unit/Entity/TypeTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\Type;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Type::class)]
 final class TypeTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new Type();
 
         $this->assertNull($entity->getIdentifier());
     }
 
-    public function testConvertToString(): void
+    #[Test]
+    public function convertToString(): void
     {
         $entity = new Type();
         $entity->name = 'Douze';

--- a/tests/src/Unit/Entity/VariantFormTest.php
+++ b/tests/src/Unit/Entity/VariantFormTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Entity;
 
 use App\Entity\VariantForm;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,14 +15,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(VariantForm::class)]
 final class VariantFormTest extends TestCase
 {
-    public function testGetIdentifierDefault(): void
+    #[Test]
+    public function getIdentifierDefault(): void
     {
         $entity = new VariantForm();
 
         $this->assertNull($entity->getIdentifier());
     }
 
-    public function testConvertToString(): void
+    #[Test]
+    public function convertToString(): void
     {
         $entity = new VariantForm();
         $entity->name = 'Douze';

--- a/tests/src/Unit/Helper/A1NotationTest.php
+++ b/tests/src/Unit/Helper/A1NotationTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Helper;
 use App\Helper\A1Notation;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,8 +16,9 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(A1Notation::class)]
 final class A1NotationTest extends TestCase
 {
+    #[Test]
     #[DataProvider('providerIndexToLetter')]
-    public function testIndexToLetter(int $index, string $expected): void
+    public function indexToLetter(int $index, string $expected): void
     {
         $this->assertEquals($expected, A1Notation::indexToLetter($index));
     }
@@ -65,8 +67,9 @@ final class A1NotationTest extends TestCase
         ];
     }
 
+    #[Test]
     #[DataProvider('providerIndexToA1Notation')]
-    public function testFromIndex(int $rowIndex, int $columnIndex, string $expected): void
+    public function fromIndex(int $rowIndex, int $columnIndex, string $expected): void
     {
         $this->assertEquals($expected, A1Notation::fromIndex($rowIndex, $columnIndex));
     }

--- a/tests/src/Unit/Message/CalculateDexAvailabilitiesTest.php
+++ b/tests/src/Unit/Message/CalculateDexAvailabilitiesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Message;
 
 use App\Message\CalculateDexAvailabilities;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CalculateDexAvailabilities::class)]
 final class CalculateDexAvailabilitiesTest extends TestCase
 {
-    public function testSerialize(): void
+    #[Test]
+    public function serialize(): void
     {
         $message = new CalculateDexAvailabilities('12');
 

--- a/tests/src/Unit/Message/CalculateGameBundlesAvailabilitiesTest.php
+++ b/tests/src/Unit/Message/CalculateGameBundlesAvailabilitiesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Message;
 
 use App\Message\CalculateGameBundlesAvailabilities;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CalculateGameBundlesAvailabilities::class)]
 final class CalculateGameBundlesAvailabilitiesTest extends TestCase
 {
-    public function testSerialize(): void
+    #[Test]
+    public function serialize(): void
     {
         $message = new CalculateGameBundlesAvailabilities('12');
 

--- a/tests/src/Unit/Message/CalculatePokemonAvailabilitiesTest.php
+++ b/tests/src/Unit/Message/CalculatePokemonAvailabilitiesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Message;
 
 use App\Message\CalculatePokemonAvailabilities;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CalculatePokemonAvailabilities::class)]
 final class CalculatePokemonAvailabilitiesTest extends TestCase
 {
-    public function testSerialize(): void
+    #[Test]
+    public function serialize(): void
     {
         $message = new CalculatePokemonAvailabilities('12');
 

--- a/tests/src/Unit/Message/UpdateGamesAvailabilitiesTest.php
+++ b/tests/src/Unit/Message/UpdateGamesAvailabilitiesTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Message;
 
 use App\Message\UpdateGamesAvailabilities;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(UpdateGamesAvailabilities::class)]
 final class UpdateGamesAvailabilitiesTest extends TestCase
 {
-    public function testSerialize(): void
+    #[Test]
+    public function serialize(): void
     {
         $message = new UpdateGamesAvailabilities('12');
 

--- a/tests/src/Unit/Message/UpdateGamesCollectionsAndDexTest.php
+++ b/tests/src/Unit/Message/UpdateGamesCollectionsAndDexTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Message;
 
 use App\Message\UpdateGamesCollectionsAndDex;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(UpdateGamesCollectionsAndDex::class)]
 final class UpdateGamesCollectionsAndDexTest extends TestCase
 {
-    public function testSerialize(): void
+    #[Test]
+    public function serialize(): void
     {
         $message = new UpdateGamesCollectionsAndDex('12');
 

--- a/tests/src/Unit/Message/UpdateLabelsTest.php
+++ b/tests/src/Unit/Message/UpdateLabelsTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Message;
 
 use App\Message\UpdateLabels;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(UpdateLabels::class)]
 final class UpdateLabelsTest extends TestCase
 {
-    public function testSerialize(): void
+    #[Test]
+    public function serialize(): void
     {
         $message = new UpdateLabels('12');
 

--- a/tests/src/Unit/Message/UpdatePokemonsTest.php
+++ b/tests/src/Unit/Message/UpdatePokemonsTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Message;
 
 use App\Message\UpdatePokemons;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(UpdatePokemons::class)]
 final class UpdatePokemonsTest extends TestCase
 {
-    public function testSerialize(): void
+    #[Test]
+    public function serialize(): void
     {
         $message = new UpdatePokemons('12');
 

--- a/tests/src/Unit/Message/UpdateRegionalDexNumbersTest.php
+++ b/tests/src/Unit/Message/UpdateRegionalDexNumbersTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Message;
 
 use App\Message\UpdateRegionalDexNumbers;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,7 +15,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(UpdateRegionalDexNumbers::class)]
 final class UpdateRegionalDexNumbersTest extends TestCase
 {
-    public function testSerialize(): void
+    #[Test]
+    public function serialize(): void
     {
         $message = new UpdateRegionalDexNumbers('12');
 

--- a/tests/src/Unit/MessageHandler/AbstractTestCalculateHandler.php
+++ b/tests/src/Unit/MessageHandler/AbstractTestCalculateHandler.php
@@ -11,6 +11,7 @@ use App\MessageHandler\CalculateHandlerInterface;
 use App\Repository\ActionLogsRepository;
 use App\Service\CalculatorService\CalculatorServiceInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -28,7 +29,8 @@ abstract class AbstractTestCalculateHandler extends TestCase
 
     abstract public function getMessage(): AbstractActionMessage;
 
-    public function testCalculate(): void
+    #[Test]
+    public function calculate(): void
     {
         $calculatorService = $this->createMock($this->getServiceClass());
         $calculatorService
@@ -77,7 +79,8 @@ abstract class AbstractTestCalculateHandler extends TestCase
         $this->assertNull($actionLog->errorTrace);
     }
 
-    public function testCalculateError(): void
+    #[Test]
+    public function calculateError(): void
     {
         $calculatorService = $this->createMock($this->getServiceClass());
         $calculatorService

--- a/tests/src/Unit/MessageHandler/AbstractTestUpdateHandler.php
+++ b/tests/src/Unit/MessageHandler/AbstractTestUpdateHandler.php
@@ -11,6 +11,7 @@ use App\MessageHandler\UpdateHandlerInterface;
 use App\Repository\ActionLogsRepository;
 use App\Service\UpdaterService\UpdaterServiceInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -28,7 +29,8 @@ abstract class AbstractTestUpdateHandler extends TestCase
 
     abstract public function getMessage(): AbstractActionMessage;
 
-    public function testUpdate(): void
+    #[Test]
+    public function update(): void
     {
         $updaterService = $this->createMock($this->getServiceClass());
         $updaterService
@@ -77,7 +79,8 @@ abstract class AbstractTestUpdateHandler extends TestCase
         $this->assertNull($actionLog->errorTrace);
     }
 
-    public function testUpdateError(): void
+    #[Test]
+    public function updateError(): void
     {
         $updaterService = $this->createMock($this->getServiceClass());
         $updaterService

--- a/tests/src/Unit/Service/CalculatorService/PokemonAvailabilitiesCalculatorServiceTest.php
+++ b/tests/src/Unit/Service/CalculatorService/PokemonAvailabilitiesCalculatorServiceTest.php
@@ -10,6 +10,7 @@ use App\DTO\DataChangeReport\Report;
 use App\DTO\DataChangeReport\Statistic;
 use App\Service\CalculatorService\PokemonAvailabilitiesCalculatorService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,7 +19,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokemonAvailabilitiesCalculatorService::class)]
 final class PokemonAvailabilitiesCalculatorServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $gameBundleStatistic = new Statistic('gb');
         $gameBundleShinyStatistic = new Statistic('gbs');

--- a/tests/src/Unit/Service/CollectionsAvailabilitiesServiceTest.php
+++ b/tests/src/Unit/Service/CollectionsAvailabilitiesServiceTest.php
@@ -9,6 +9,7 @@ use App\Entity\Pokemon;
 use App\Repository\CollectionsAvailabilitiesRepository;
 use App\Service\CollectionsAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Cache\CacheInterface;
 
@@ -18,7 +19,8 @@ use Symfony\Contracts\Cache\CacheInterface;
 #[CoversClass(CollectionsAvailabilitiesService::class)]
 final class CollectionsAvailabilitiesServiceTest extends TestCase
 {
-    public function testGetFromPokemonWithCacheHit(): void
+    #[Test]
+    public function getFromPokemonWithCacheHit(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'pikachu';
@@ -45,7 +47,8 @@ final class CollectionsAvailabilitiesServiceTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testGetFromPokemonWithCacheMiss(): void
+    #[Test]
+    public function getFromPokemonWithCacheMiss(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'charizard';
@@ -77,7 +80,8 @@ final class CollectionsAvailabilitiesServiceTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testCleanCacheFromPokemon(): void
+    #[Test]
+    public function cleanCacheFromPokemon(): void
     {
         $repository = $this->createMock(CollectionsAvailabilitiesRepository::class);
         $repository

--- a/tests/src/Unit/Service/GameBundlesAvailabilitiesServiceTest.php
+++ b/tests/src/Unit/Service/GameBundlesAvailabilitiesServiceTest.php
@@ -9,6 +9,7 @@ use App\Entity\Pokemon;
 use App\Repository\GameBundlesAvailabilitiesRepository;
 use App\Service\GameBundlesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Cache\CacheInterface;
 
@@ -18,7 +19,8 @@ use Symfony\Contracts\Cache\CacheInterface;
 #[CoversClass(GameBundlesAvailabilitiesService::class)]
 final class GameBundlesAvailabilitiesServiceTest extends TestCase
 {
-    public function testGetFromPokemonWithCacheHit(): void
+    #[Test]
+    public function getFromPokemonWithCacheHit(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'pikachu';
@@ -45,7 +47,8 @@ final class GameBundlesAvailabilitiesServiceTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testGetFromPokemonWithCacheMiss(): void
+    #[Test]
+    public function getFromPokemonWithCacheMiss(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'charizard';
@@ -77,7 +80,8 @@ final class GameBundlesAvailabilitiesServiceTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testCleanCacheFromPokemon(): void
+    #[Test]
+    public function cleanCacheFromPokemon(): void
     {
         $repository = $this->createMock(GameBundlesAvailabilitiesRepository::class);
         $repository

--- a/tests/src/Unit/Service/GameBundlesShiniesAvailabilitiesServiceTest.php
+++ b/tests/src/Unit/Service/GameBundlesShiniesAvailabilitiesServiceTest.php
@@ -9,6 +9,7 @@ use App\Entity\Pokemon;
 use App\Repository\GameBundlesShiniesAvailabilitiesRepository;
 use App\Service\GameBundlesShiniesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Cache\CacheInterface;
 
@@ -18,7 +19,8 @@ use Symfony\Contracts\Cache\CacheInterface;
 #[CoversClass(GameBundlesShiniesAvailabilitiesService::class)]
 final class GameBundlesShiniesAvailabilitiesServiceTest extends TestCase
 {
-    public function testGetFromPokemonWithCacheHit(): void
+    #[Test]
+    public function getFromPokemonWithCacheHit(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'pikachu';
@@ -45,7 +47,8 @@ final class GameBundlesShiniesAvailabilitiesServiceTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testGetFromPokemonWithCacheMiss(): void
+    #[Test]
+    public function getFromPokemonWithCacheMiss(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'charizard';
@@ -77,7 +80,8 @@ final class GameBundlesShiniesAvailabilitiesServiceTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testCleanCacheFromPokemon(): void
+    #[Test]
+    public function cleanCacheFromPokemon(): void
     {
         $repository = $this->createMock(GameBundlesShiniesAvailabilitiesRepository::class);
         $repository

--- a/tests/src/Unit/Service/GamesAvailabilitiesServiceTest.php
+++ b/tests/src/Unit/Service/GamesAvailabilitiesServiceTest.php
@@ -9,6 +9,7 @@ use App\Entity\Pokemon;
 use App\Repository\GamesAvailabilitiesRepository;
 use App\Service\GamesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Cache\CacheInterface;
 
@@ -18,7 +19,8 @@ use Symfony\Contracts\Cache\CacheInterface;
 #[CoversClass(GamesAvailabilitiesService::class)]
 final class GamesAvailabilitiesServiceTest extends TestCase
 {
-    public function testGetFromPokemonWithCacheHit(): void
+    #[Test]
+    public function getFromPokemonWithCacheHit(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'pikachu';
@@ -45,7 +47,8 @@ final class GamesAvailabilitiesServiceTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testGetFromPokemonWithCacheMiss(): void
+    #[Test]
+    public function getFromPokemonWithCacheMiss(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'charizard';
@@ -77,7 +80,8 @@ final class GamesAvailabilitiesServiceTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testCleanCacheFromPokemon(): void
+    #[Test]
+    public function cleanCacheFromPokemon(): void
     {
         $repository = $this->createMock(GamesAvailabilitiesRepository::class);
         $repository

--- a/tests/src/Unit/Service/GamesShiniesAvailabilitiesServiceTest.php
+++ b/tests/src/Unit/Service/GamesShiniesAvailabilitiesServiceTest.php
@@ -9,6 +9,7 @@ use App\Entity\Pokemon;
 use App\Repository\GamesShiniesAvailabilitiesRepository;
 use App\Service\GamesShiniesAvailabilitiesService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Cache\CacheInterface;
 
@@ -18,7 +19,8 @@ use Symfony\Contracts\Cache\CacheInterface;
 #[CoversClass(GamesShiniesAvailabilitiesService::class)]
 final class GamesShiniesAvailabilitiesServiceTest extends TestCase
 {
-    public function testGetFromPokemonWithCacheHit(): void
+    #[Test]
+    public function getFromPokemonWithCacheHit(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'pikachu';
@@ -45,7 +47,8 @@ final class GamesShiniesAvailabilitiesServiceTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testGetFromPokemonWithCacheMiss(): void
+    #[Test]
+    public function getFromPokemonWithCacheMiss(): void
     {
         $pokemon = new Pokemon();
         $pokemon->slug = 'charizard';
@@ -77,7 +80,8 @@ final class GamesShiniesAvailabilitiesServiceTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function testCleanCacheFromPokemon(): void
+    #[Test]
+    public function cleanCacheFromPokemon(): void
     {
         $repository = $this->createMock(GamesShiniesAvailabilitiesRepository::class);
         $repository

--- a/tests/src/Unit/Service/GetNPokemonsToChooseServiceTest.php
+++ b/tests/src/Unit/Service/GetNPokemonsToChooseServiceTest.php
@@ -9,6 +9,7 @@ use App\Service\GetNPokemonsToChooseService;
 use App\Service\GetNPokemonsToPickService;
 use App\Service\GetNPokemonsToVoteService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -17,7 +18,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GetNPokemonsToChooseService::class)]
 final class GetNPokemonsToChooseServiceTest extends TestCase
 {
-    public function testFromToPick(): void
+    #[Test]
+    public function fromToPick(): void
     {
         $queryOptions = new TrainerPokemonEloListQueryOptions([
             'trainer_external_id' => 'bd307a3ec329e10a2cff8fb87480823da114f8f4',
@@ -60,7 +62,8 @@ final class GetNPokemonsToChooseServiceTest extends TestCase
         );
     }
 
-    public function testFromToVote(): void
+    #[Test]
+    public function fromToVote(): void
     {
         $queryOptions = new TrainerPokemonEloListQueryOptions([
             'trainer_external_id' => 'bd307a3ec329e10a2cff8fb87480823da114f8f4',

--- a/tests/src/Unit/Service/GetNPokemonsToVoteServiceTest.php
+++ b/tests/src/Unit/Service/GetNPokemonsToVoteServiceTest.php
@@ -8,6 +8,7 @@ use App\DTO\TrainerPokemonEloListQueryOptions;
 use App\Repository\PokemonsRepository;
 use App\Service\GetNPokemonsToVoteService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GetNPokemonsToVoteService::class)]
 final class GetNPokemonsToVoteServiceTest extends TestCase
 {
-    public function testGetNPokemonsToVote(): void
+    #[Test]
+    public function getNPokemonsToVote(): void
     {
         $queryOptions = new TrainerPokemonEloListQueryOptions([
             'trainer_external_id' => 'bd307a3ec329e10a2cff8fb87480823da114f8f4',

--- a/tests/src/Unit/Service/PokedexServiceTest.php
+++ b/tests/src/Unit/Service/PokedexServiceTest.php
@@ -8,6 +8,7 @@ use App\Repository\PokedexRepository;
 use App\Service\PokedexService;
 use App\Service\PropagateCatchStateService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokedexService::class)]
 final class PokedexServiceTest extends TestCase
 {
-    public function testGetCatchStateCountsDefinedByTrainer(): void
+    #[Test]
+    public function getCatchStateCountsDefinedByTrainer(): void
     {
         $repository = $this->createMock(PokedexRepository::class);
         $repository->expects($this->once())
@@ -52,7 +54,8 @@ final class PokedexServiceTest extends TestCase
         );
     }
 
-    public function testGetDexUsage(): void
+    #[Test]
+    public function getDexUsage(): void
     {
         $repository = $this->createMock(PokedexRepository::class);
         $repository->expects($this->once())
@@ -102,7 +105,8 @@ final class PokedexServiceTest extends TestCase
         );
     }
 
-    public function testGetCatchStateUsage(): void
+    #[Test]
+    public function getCatchStateUsage(): void
     {
         $repository = $this->createMock(PokedexRepository::class);
         $repository->expects($this->once())
@@ -170,7 +174,8 @@ final class PokedexServiceTest extends TestCase
         );
     }
 
-    public function testUpsertReturnsOnlyOriginWhenNothingChanged(): void
+    #[Test]
+    public function upsertReturnsOnlyOriginWhenNothingChanged(): void
     {
         $repository = $this->createMock(PokedexRepository::class);
         $repository->expects($this->once())
@@ -190,7 +195,8 @@ final class PokedexServiceTest extends TestCase
         );
     }
 
-    public function testUpsertPropagatesWhenOriginChanged(): void
+    #[Test]
+    public function upsertPropagatesWhenOriginChanged(): void
     {
         $repository = $this->createMock(PokedexRepository::class);
         $repository->expects($this->once())
@@ -214,7 +220,8 @@ final class PokedexServiceTest extends TestCase
         );
     }
 
-    public function testUpsertPropagatesNothingWhenCascadeReturnsEmptyList(): void
+    #[Test]
+    public function upsertPropagatesNothingWhenCascadeReturnsEmptyList(): void
     {
         $repository = $this->createMock(PokedexRepository::class);
         $repository->expects($this->once())

--- a/tests/src/Unit/Service/PropagateCatchStateServiceTest.php
+++ b/tests/src/Unit/Service/PropagateCatchStateServiceTest.php
@@ -8,6 +8,7 @@ use App\Repository\PokedexRepository;
 use App\Repository\TrainerDexLinkRepository;
 use App\Service\PropagateCatchStateService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,7 +17,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PropagateCatchStateService::class)]
 final class PropagateCatchStateServiceTest extends TestCase
 {
-    public function testPropagatesToDirectNeighbourWhenValueChanges(): void
+    #[Test]
+    public function propagatesToDirectNeighbourWhenValueChanges(): void
     {
         $linkRepository = $this->createMock(TrainerDexLinkRepository::class);
         $linkRepository->expects($this->exactly(2))
@@ -42,7 +44,8 @@ final class PropagateCatchStateServiceTest extends TestCase
         );
     }
 
-    public function testStopsAtANodeWhoseValueDidNotChange(): void
+    #[Test]
+    public function stopsAtANodeWhoseValueDidNotChange(): void
     {
         $linkRepository = $this->createMock(TrainerDexLinkRepository::class);
         $linkRepository->expects($this->once())
@@ -66,7 +69,8 @@ final class PropagateCatchStateServiceTest extends TestCase
         );
     }
 
-    public function testPropagatesTransitivelyThroughAChain(): void
+    #[Test]
+    public function propagatesTransitivelyThroughAChain(): void
     {
         $linkRepository = $this->createMock(TrainerDexLinkRepository::class);
         $linkRepository->expects($this->exactly(3))
@@ -95,7 +99,8 @@ final class PropagateCatchStateServiceTest extends TestCase
         );
     }
 
-    public function testCycleTerminatesByIdempotenceWithoutInfiniteLoop(): void
+    #[Test]
+    public function cycleTerminatesByIdempotenceWithoutInfiniteLoop(): void
     {
         // A <-> B: origin is A, edge A -> B, and B -> A also exists.
         $linkRepository = $this->createMock(TrainerDexLinkRepository::class);
@@ -126,7 +131,8 @@ final class PropagateCatchStateServiceTest extends TestCase
         );
     }
 
-    public function testThreeNodeCycleTerminatesByIdempotence(): void
+    #[Test]
+    public function threeNodeCycleTerminatesByIdempotence(): void
     {
         // A -> B -> C -> A. Origin A was already written by the caller before propagate() runs,
         // so by the time the cycle comes back around to A, upsertIfDifferent('dex-a', ...) is a no-op.
@@ -158,7 +164,8 @@ final class PropagateCatchStateServiceTest extends TestCase
         );
     }
 
-    public function testPokemonAbsentFromAnIntermediateDexSkipsTheWriteButKeepsTraversing(): void
+    #[Test]
+    public function pokemonAbsentFromAnIntermediateDexSkipsTheWriteButKeepsTraversing(): void
     {
         // A -> B -> C, pokemon isn't in B's DexAvailability (upsertIfDifferent returns false for that reason)
         // but traversal must still continue from B to C per the design.
@@ -188,7 +195,8 @@ final class PropagateCatchStateServiceTest extends TestCase
         );
     }
 
-    public function testFanOutContinuesToSiblingEdgeAfterANoChangeSibling(): void
+    #[Test]
+    public function fanOutContinuesToSiblingEdgeAfterANoChangeSibling(): void
     {
         // A -> B and A -> C are two sibling edges discovered together from A's single
         // expansion (both already queued before either is processed). B is idempotent
@@ -223,7 +231,8 @@ final class PropagateCatchStateServiceTest extends TestCase
         );
     }
 
-    public function testFanOutPreservesPendingSiblingEdgeWhenAppendingNewlyDiscoveredOnes(): void
+    #[Test]
+    public function fanOutPreservesPendingSiblingEdgeWhenAppendingNewlyDiscoveredOnes(): void
     {
         // A -> B and A -> C are two sibling edges discovered together from A's single
         // expansion. B changes AND has its own further outgoing edge to D. The still-queued
@@ -263,7 +272,8 @@ final class PropagateCatchStateServiceTest extends TestCase
         );
     }
 
-    public function testNoOutgoingEdgesReturnsEmptyList(): void
+    #[Test]
+    public function noOutgoingEdgesReturnsEmptyList(): void
     {
         $linkRepository = $this->createMock(TrainerDexLinkRepository::class);
         $linkRepository->expects($this->once())

--- a/tests/src/Unit/Service/SpreadsheetServiceTest.php
+++ b/tests/src/Unit/Service/SpreadsheetServiceTest.php
@@ -12,6 +12,7 @@ use Google\Service\Sheets\SheetProperties;
 use Google\Service\Sheets\Spreadsheet;
 use Google\Service\Sheets\ValueRange;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
@@ -21,7 +22,8 @@ use Psr\Log\NullLogger;
 #[CoversClass(SpreadsheetService::class)]
 final class SpreadsheetServiceTest extends TestCase
 {
-    public function testGet(): void
+    #[Test]
+    public function get(): void
     {
         $logger = new NullLogger();
         $client = $this->createMock(Client::class);
@@ -46,7 +48,8 @@ final class SpreadsheetServiceTest extends TestCase
         $service->get('azertyuiop', 'A1:R12');
     }
 
-    public function testGetSheetRowCount(): void
+    #[Test]
+    public function getSheetRowCount(): void
     {
         $service = $this->getServiceForGettingProperties();
 
@@ -56,7 +59,8 @@ final class SpreadsheetServiceTest extends TestCase
         );
     }
 
-    public function testGetSheetColumnCount(): void
+    #[Test]
+    public function getSheetColumnCount(): void
     {
         $service = $this->getServiceForGettingProperties();
 
@@ -66,7 +70,8 @@ final class SpreadsheetServiceTest extends TestCase
         );
     }
 
-    public function testGetSheetColumnCountNonExistingSheet(): void
+    #[Test]
+    public function getSheetColumnCountNonExistingSheet(): void
     {
         $service = $this->getServiceForGettingProperties();
 

--- a/tests/src/Unit/Service/SqlFileLoaderTest.php
+++ b/tests/src/Unit/Service/SqlFileLoaderTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Service;
 
 use App\Service\SqlFileLoader;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -35,7 +36,8 @@ final class SqlFileLoaderTest extends TestCase
         rmdir($this->tempDir);
     }
 
-    public function testLoadReturnsFileContent(): void
+    #[Test]
+    public function loadReturnsFileContent(): void
     {
         file_put_contents($this->tempDir.'/test.sql', 'SELECT 1');
         $loader = new SqlFileLoader($this->tempDir);
@@ -43,7 +45,8 @@ final class SqlFileLoaderTest extends TestCase
         $this->assertSame('SELECT 1', $loader->load('test.sql'));
     }
 
-    public function testLoadThrowsOnMissingFile(): void
+    #[Test]
+    public function loadThrowsOnMissingFile(): void
     {
         $loader = new SqlFileLoader($this->tempDir);
 
@@ -52,7 +55,8 @@ final class SqlFileLoaderTest extends TestCase
         $loader->load('missing.sql');
     }
 
-    public function testAllReferencedSqlFilesExist(): void
+    #[Test]
+    public function allReferencedSqlFilesExist(): void
     {
         $loader = new SqlFileLoader(dirname(__DIR__, 4).'/resources/sql');
 

--- a/tests/src/Unit/Service/TrainerDexLinkServiceTest.php
+++ b/tests/src/Unit/Service/TrainerDexLinkServiceTest.php
@@ -12,6 +12,7 @@ use App\Repository\TrainerDexLinkRepository;
 use App\Repository\TrainerDexRepository;
 use App\Service\TrainerDexLinkService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Uid\Uuid;
 
@@ -21,7 +22,8 @@ use Symfony\Component\Uid\Uuid;
 #[CoversClass(TrainerDexLinkService::class)]
 final class TrainerDexLinkServiceTest extends TestCase
 {
-    public function testListForDexDelegatesToRepository(): void
+    #[Test]
+    public function listForDexDelegatesToRepository(): void
     {
         $linkRepository = $this->createMock(TrainerDexLinkRepository::class);
         $linkRepository->expects($this->once())
@@ -37,7 +39,8 @@ final class TrainerDexLinkServiceTest extends TestCase
         $this->assertSame([['id' => 'link-1']], $service->listForDex('trainer-1', 'national'));
     }
 
-    public function testCreateRejectsSelfLink(): void
+    #[Test]
+    public function createRejectsSelfLink(): void
     {
         $linkRepository = $this->createMock(TrainerDexLinkRepository::class);
         $linkRepository->expects($this->never())->method('exists');
@@ -53,7 +56,8 @@ final class TrainerDexLinkServiceTest extends TestCase
         $service->create('trainer-1', 'national', 'national', false);
     }
 
-    public function testCreateRejectsUnknownSourceDex(): void
+    #[Test]
+    public function createRejectsUnknownSourceDex(): void
     {
         $linkRepository = $this->createMock(TrainerDexLinkRepository::class);
 
@@ -71,7 +75,8 @@ final class TrainerDexLinkServiceTest extends TestCase
         $service->create('trainer-1', 'unknown', 'shiny', false);
     }
 
-    public function testCreateRejectsUnknownTargetDex(): void
+    #[Test]
+    public function createRejectsUnknownTargetDex(): void
     {
         $source = new TrainerDex();
 
@@ -93,7 +98,8 @@ final class TrainerDexLinkServiceTest extends TestCase
         $service->create('trainer-1', 'national', 'unknown', false);
     }
 
-    public function testCreateRejectsDuplicateEdge(): void
+    #[Test]
+    public function createRejectsDuplicateEdge(): void
     {
         $source = $this->trainerDexWithId('11111111-1111-1111-1111-111111111111');
         $target = $this->trainerDexWithId('22222222-2222-2222-2222-222222222222');
@@ -116,7 +122,8 @@ final class TrainerDexLinkServiceTest extends TestCase
         $service->create('trainer-1', 'national', 'shiny', false);
     }
 
-    public function testCreateInsertsOneRowForAUnidirectionalLink(): void
+    #[Test]
+    public function createInsertsOneRowForAUnidirectionalLink(): void
     {
         $source = $this->trainerDexWithId('11111111-1111-1111-1111-111111111111');
         $target = $this->trainerDexWithId('22222222-2222-2222-2222-222222222222');
@@ -141,7 +148,8 @@ final class TrainerDexLinkServiceTest extends TestCase
         $service->create('trainer-1', 'national', 'shiny', false);
     }
 
-    public function testCreateRejectsWhenTheReverseEdgeOfABidirectionalLinkAlreadyExists(): void
+    #[Test]
+    public function createRejectsWhenTheReverseEdgeOfABidirectionalLinkAlreadyExists(): void
     {
         $source = $this->trainerDexWithId('11111111-1111-1111-1111-111111111111');
         $target = $this->trainerDexWithId('22222222-2222-2222-2222-222222222222');
@@ -166,7 +174,8 @@ final class TrainerDexLinkServiceTest extends TestCase
     /**
      * @SuppressWarnings("PHPMD.UnusedFormalParameter")
      */
-    public function testCreateInsertsTwoRowsSharingAPairIdForABidirectionalLink(): void
+    #[Test]
+    public function createInsertsTwoRowsSharingAPairIdForABidirectionalLink(): void
     {
         $source = $this->trainerDexWithId('11111111-1111-1111-1111-111111111111');
         $target = $this->trainerDexWithId('22222222-2222-2222-2222-222222222222');
@@ -195,7 +204,8 @@ final class TrainerDexLinkServiceTest extends TestCase
         $this->assertTrue(Uuid::isValid($pairIds[0]));
     }
 
-    public function testDeleteDelegatesToRepository(): void
+    #[Test]
+    public function deleteDelegatesToRepository(): void
     {
         $linkRepository = $this->createMock(TrainerDexLinkRepository::class);
         $linkRepository->expects($this->once())

--- a/tests/src/Unit/Service/TrainerDexServiceTest.php
+++ b/tests/src/Unit/Service/TrainerDexServiceTest.php
@@ -9,6 +9,7 @@ use App\DTO\TrainerDexAttributes;
 use App\Repository\TrainerDexRepository;
 use App\Service\TrainerDexService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -17,7 +18,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(TrainerDexService::class)]
 final class TrainerDexServiceTest extends TestCase
 {
-    public function testInsertIfNeeded(): void
+    #[Test]
+    public function insertIfNeeded(): void
     {
         $repository = $this->createMock(TrainerDexRepository::class);
         $repository->expects($this->once())
@@ -30,7 +32,8 @@ final class TrainerDexServiceTest extends TestCase
         $service->insertIfNeeded('7b52009b64fd0a2a49e6d8a939753077792b0554', 'bw2');
     }
 
-    public function testGetListQuery(): void
+    #[Test]
+    public function getListQuery(): void
     {
         $queryOptions = new DexQueryOptions([
             'include_unreleased_dex' => false,
@@ -47,7 +50,8 @@ final class TrainerDexServiceTest extends TestCase
         $service->getListQuery('7b52009b64fd0a2a49e6d8a939753077792b0554', $queryOptions);
     }
 
-    public function testSet(): void
+    #[Test]
+    public function set(): void
     {
         $attributes = new TrainerDexAttributes([
             'is_on_home' => false,

--- a/tests/src/Unit/Service/UpdaterService/CollectionsAvailabilitiesUpdaterServiceTest.php
+++ b/tests/src/Unit/Service/UpdaterService/CollectionsAvailabilitiesUpdaterServiceTest.php
@@ -8,6 +8,7 @@ use App\DTO\DataChangeReport\Statistic;
 use App\Service\UpdaterService\CollectionsAvailabilitiesUpdaterService;
 use App\Updater\CollectionsAvailabilitiesUpdater;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,14 +17,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CollectionsAvailabilitiesUpdaterService::class)]
 final class CollectionsAvailabilitiesUpdaterServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $service = $this->getService();
 
         $service->execute();
     }
 
-    public function testGetReport(): void
+    #[Test]
+    public function getReport(): void
     {
         $service = $this->getService();
 

--- a/tests/src/Unit/Service/UpdaterService/CollectionsUpdaterServiceTest.php
+++ b/tests/src/Unit/Service/UpdaterService/CollectionsUpdaterServiceTest.php
@@ -8,6 +8,7 @@ use App\DTO\DataChangeReport\Statistic;
 use App\Service\UpdaterService\CollectionsUpdaterService;
 use App\Updater\CollectionsUpdater;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,14 +17,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CollectionsUpdaterService::class)]
 final class CollectionsUpdaterServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $service = $this->getService();
 
         $service->execute();
     }
 
-    public function testGetReport(): void
+    #[Test]
+    public function getReport(): void
     {
         $service = $this->getService();
 

--- a/tests/src/Unit/Service/UpdaterService/DexUpdaterServiceTest.php
+++ b/tests/src/Unit/Service/UpdaterService/DexUpdaterServiceTest.php
@@ -8,6 +8,7 @@ use App\DTO\DataChangeReport\Statistic;
 use App\Service\UpdaterService\DexUpdaterService;
 use App\Updater\DexUpdater;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,14 +17,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(DexUpdaterService::class)]
 final class DexUpdaterServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $service = $this->getService();
 
         $service->execute();
     }
 
-    public function testGetReport(): void
+    #[Test]
+    public function getReport(): void
     {
         $service = $this->getService();
 

--- a/tests/src/Unit/Service/UpdaterService/FormsUpdaterServiceTest.php
+++ b/tests/src/Unit/Service/UpdaterService/FormsUpdaterServiceTest.php
@@ -11,6 +11,7 @@ use App\Updater\Forms\RegionalFormsUpdater;
 use App\Updater\Forms\SpecialFormsUpdater;
 use App\Updater\Forms\VariantFormsUpdater;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,14 +20,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(FormsUpdaterService::class)]
 final class FormsUpdaterServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $service = $this->getService();
 
         $service->execute();
     }
 
-    public function testGetReport(): void
+    #[Test]
+    public function getReport(): void
     {
         $service = $this->getService();
 

--- a/tests/src/Unit/Service/UpdaterService/GamesAvailabilitiesUpdaterServiceTest.php
+++ b/tests/src/Unit/Service/UpdaterService/GamesAvailabilitiesUpdaterServiceTest.php
@@ -8,6 +8,7 @@ use App\DTO\DataChangeReport\Statistic;
 use App\Service\UpdaterService\GamesAvailabilitiesUpdaterService;
 use App\Updater\GamesAvailabilitiesUpdater;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,14 +17,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GamesAvailabilitiesUpdaterService::class)]
 final class GamesAvailabilitiesUpdaterServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $service = $this->getService();
 
         $service->execute();
     }
 
-    public function testGetReport(): void
+    #[Test]
+    public function getReport(): void
     {
         $service = $this->getService();
 

--- a/tests/src/Unit/Service/UpdaterService/GamesCollectionsAndDexUpdaterServiceTest.php
+++ b/tests/src/Unit/Service/UpdaterService/GamesCollectionsAndDexUpdaterServiceTest.php
@@ -11,6 +11,7 @@ use App\Service\UpdaterService\DexUpdaterService;
 use App\Service\UpdaterService\GamesCollectionsAndDexUpdaterService;
 use App\Service\UpdaterService\GamesUpdaterService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,14 +20,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GamesCollectionsAndDexUpdaterService::class)]
 final class GamesCollectionsAndDexUpdaterServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $service = $this->getService();
 
         $service->execute();
     }
 
-    public function testGetReport(): void
+    #[Test]
+    public function getReport(): void
     {
         $service = $this->getService();
 

--- a/tests/src/Unit/Service/UpdaterService/GamesShiniesAvailabilitiesUpdaterServiceTest.php
+++ b/tests/src/Unit/Service/UpdaterService/GamesShiniesAvailabilitiesUpdaterServiceTest.php
@@ -8,6 +8,7 @@ use App\DTO\DataChangeReport\Statistic;
 use App\Service\UpdaterService\GamesShiniesAvailabilitiesUpdaterService;
 use App\Updater\GamesShiniesAvailabilitiesUpdater;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,14 +17,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GamesShiniesAvailabilitiesUpdaterService::class)]
 final class GamesShiniesAvailabilitiesUpdaterServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $service = $this->getService();
 
         $service->execute();
     }
 
-    public function testGetReport(): void
+    #[Test]
+    public function getReport(): void
     {
         $service = $this->getService();
 

--- a/tests/src/Unit/Service/UpdaterService/GamesUpdaterServiceTest.php
+++ b/tests/src/Unit/Service/UpdaterService/GamesUpdaterServiceTest.php
@@ -10,6 +10,7 @@ use App\Updater\GameBundlesUpdater;
 use App\Updater\GameGenerationsUpdater;
 use App\Updater\GamesUpdater;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,14 +19,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(GamesUpdaterService::class)]
 final class GamesUpdaterServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $service = $this->getService();
 
         $service->execute();
     }
 
-    public function testGetReport(): void
+    #[Test]
+    public function getReport(): void
     {
         $service = $this->getService();
 

--- a/tests/src/Unit/Service/UpdaterService/LabelsUpdaterServiceTest.php
+++ b/tests/src/Unit/Service/UpdaterService/LabelsUpdaterServiceTest.php
@@ -12,6 +12,7 @@ use App\Updater\CatchStatesUpdater;
 use App\Updater\RegionsUpdater;
 use App\Updater\TypesUpdater;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,14 +21,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(LabelsUpdaterService::class)]
 final class LabelsUpdaterServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $service = $this->getService();
 
         $service->execute();
     }
 
-    public function testGetReport(): void
+    #[Test]
+    public function getReport(): void
     {
         $service = $this->getService();
 

--- a/tests/src/Unit/Service/UpdaterService/PokemonsUpdaterServiceTest.php
+++ b/tests/src/Unit/Service/UpdaterService/PokemonsUpdaterServiceTest.php
@@ -8,6 +8,7 @@ use App\DTO\DataChangeReport\Statistic;
 use App\Service\UpdaterService\PokemonsUpdaterService;
 use App\Updater\PokemonsUpdater;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,14 +17,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PokemonsUpdaterService::class)]
 final class PokemonsUpdaterServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $service = $this->getService();
 
         $service->execute();
     }
 
-    public function testGetReport(): void
+    #[Test]
+    public function getReport(): void
     {
         $service = $this->getService();
 

--- a/tests/src/Unit/Service/UpdaterService/RegionalDexNumbersUpdaterServiceTest.php
+++ b/tests/src/Unit/Service/UpdaterService/RegionalDexNumbersUpdaterServiceTest.php
@@ -8,6 +8,7 @@ use App\DTO\DataChangeReport\Statistic;
 use App\Service\UpdaterService\RegionalDexNumbersUpdaterService;
 use App\Updater\RegionalDexNumbersUpdater;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,14 +17,16 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(RegionalDexNumbersUpdaterService::class)]
 final class RegionalDexNumbersUpdaterServiceTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $service = $this->getService();
 
         $service->execute();
     }
 
-    public function testGetReport(): void
+    #[Test]
+    public function getReport(): void
     {
         $service = $this->getService();
 

--- a/tests/src/Unit/Service/VersionServiceTest.php
+++ b/tests/src/Unit/Service/VersionServiceTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Unit\Service;
 
 use App\Service\VersionService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -35,7 +36,8 @@ final class VersionServiceTest extends TestCase
         rmdir($this->tempDir);
     }
 
-    public function testGetVersionReturnsTrimmedFileContent(): void
+    #[Test]
+    public function getVersionReturnsTrimmedFileContent(): void
     {
         file_put_contents($this->tempDir.'/version', "1.2.12\n");
         $service = new VersionService($this->tempDir);
@@ -43,14 +45,16 @@ final class VersionServiceTest extends TestCase
         $this->assertSame('1.2.12', $service->getVersion());
     }
 
-    public function testGetVersionReturnsFallbackWhenFileMissing(): void
+    #[Test]
+    public function getVersionReturnsFallbackWhenFileMissing(): void
     {
         $service = new VersionService($this->tempDir);
 
         $this->assertSame('unknown', $service->getVersion());
     }
 
-    public function testGetUpdatedAtReturnsFileMtime(): void
+    #[Test]
+    public function getUpdatedAtReturnsFileMtime(): void
     {
         file_put_contents($this->tempDir.'/version', "1.2.12\n");
         $expectedMtime = filemtime($this->tempDir.'/version');
@@ -59,7 +63,8 @@ final class VersionServiceTest extends TestCase
         $this->assertSame($expectedMtime, $service->getUpdatedAt()?->getTimestamp());
     }
 
-    public function testGetUpdatedAtReturnsNullWhenFileMissing(): void
+    #[Test]
+    public function getUpdatedAtReturnsNullWhenFileMissing(): void
     {
         $service = new VersionService($this->tempDir);
 

--- a/tests/src/Unit/Updater/CatchStatesUpdaterTest.php
+++ b/tests/src/Unit/Updater/CatchStatesUpdaterTest.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Google\Service\Exception as GoogleServiceException;
 use Google\Service\Sheets\ValueRange;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -21,7 +22,8 @@ use Psr\Log\LoggerInterface;
 #[CoversClass(CatchStatesUpdater::class)]
 final class CatchStatesUpdaterTest extends TestCase
 {
-    public function testGettingSpreasheetLog(): void
+    #[Test]
+    public function gettingSpreasheetLog(): void
     {
         $exception = new GoogleServiceException('Something bad happenned');
 
@@ -63,7 +65,8 @@ final class CatchStatesUpdaterTest extends TestCase
         $updater->execute('douze');
     }
 
-    public function testGettingEmptyHeaderLog(): void
+    #[Test]
+    public function gettingEmptyHeaderLog(): void
     {
         $headerRange = new ValueRange();
         $headerRange->values = [];
@@ -106,7 +109,8 @@ final class CatchStatesUpdaterTest extends TestCase
         $updater->execute('douze');
     }
 
-    public function testGettingInvalidHeaderLog(): void
+    #[Test]
+    public function gettingInvalidHeaderLog(): void
     {
         $headerRange = new ValueRange();
         $headerRange->values = [
@@ -164,7 +168,8 @@ final class CatchStatesUpdaterTest extends TestCase
         $updater->execute('douze');
     }
 
-    public function testGettingEmptyRecordLog(): void
+    #[Test]
+    public function gettingEmptyRecordLog(): void
     {
         $headerRange = new ValueRange();
         $headerRange->values = [

--- a/tests/src/Unit/Updater/DexUpdaterTest.php
+++ b/tests/src/Unit/Updater/DexUpdaterTest.php
@@ -10,6 +10,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Google\Service\Sheets\ValueRange;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -19,14 +20,16 @@ use Psr\Log\LoggerInterface;
 #[CoversClass(DexUpdater::class)]
 final class DexUpdaterTest extends TestCase
 {
-    public function testExecute(): void
+    #[Test]
+    public function execute(): void
     {
         $updater = $this->getService();
 
         $updater->execute('douze');
     }
 
-    public function testStatistic(): void
+    #[Test]
+    public function statistic(): void
     {
         $updater = $this->getService();
 

--- a/tests/src/Unit/Updater/PokemonsUpdaterTest.php
+++ b/tests/src/Unit/Updater/PokemonsUpdaterTest.php
@@ -8,6 +8,7 @@ use App\Service\SpreadsheetService;
 use App\Updater\PokemonsUpdater;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 
@@ -17,7 +18,8 @@ use Psr\Log\LoggerInterface;
 #[CoversClass(PokemonsUpdater::class)]
 final class PokemonsUpdaterTest extends TestCase
 {
-    public function testTransformRecordMapsFieldsCorrectly(): void
+    #[Test]
+    public function transformRecordMapsFieldsCorrectly(): void
     {
         $spreadsheetService = $this->createStub(SpreadsheetService::class);
         $entityManager = $this->createStub(EntityManagerInterface::class);


### PR DESCRIPTION
## Summary
- Migrates all remaining `testXxx()` methods to the `#[Test]` attribute with the `test` prefix dropped, matching the style already used in the 114 files that had it.
- Audited every `createMock` assigned to a variable for a matching `->expects(...)` call: none qualified for `createStub` (all 63 files already only use `createMock` where an expectation is actually set — 13 files already correctly use `createStub` elsewhere).

## Notes
- `tests/src/Integration/Controller/Debug/DebugDexControllerTest.php` was left untouched: its 4 methods already carry `#[Test]` but kept the `test` prefix (pre-existing inconsistency, out of the strict scope of "methods without the attribute").
- No tests were run while producing this change (by request) — please run the full suite before merging.

## Test plan
- [ ] `make tests` passes
- [ ] `make quality` / `make measures` still green (coverage/MSI)